### PR TITLE
Use Packaged ros-jazzy-camera-ros

### DIFF
--- a/build_scripts/build-core.sh
+++ b/build_scripts/build-core.sh
@@ -117,7 +117,7 @@ cd $DIR
 
 # Build the core
 if [ "$ROS_DISTRO" == "humble" ] || [ "$ROS_DISTRO" == "jazzy" ]; then
-    colcon build --packages-up-to deepracer_launcher logging_pkg camera_ros $COLCON_BUILD_ARGS --cmake-args $CMAKE_ARGS
+    colcon build --packages-up-to deepracer_launcher logging_pkg $COLCON_BUILD_ARGS --cmake-args $CMAKE_ARGS
 else
     colcon build --packages-up-to deepracer_launcher rplidar_ros logging_pkg $COLCON_BUILD_ARGS --cmake-args $CMAKE_ARGS
 fi

--- a/build_scripts/build-libcamera.sh
+++ b/build_scripts/build-libcamera.sh
@@ -39,11 +39,11 @@ VERSION=1:${VERSION_BASE}-$(lsb_release -cs)
 
 cd $DIR/deps/
 if [ ! -d "$DIR/deps/libcamera" ]; then
-    git clone --branch v0.5.2+rpt20250903 https://github.com/raspberrypi/libcamera.git
+    git clone --branch v0.7.1+rpt20260429 https://github.com/raspberrypi/libcamera.git
 else
     cd $DIR/deps/libcamera
     git fetch origin
-    git checkout v0.5.2+rpt20250903
+    git checkout v0.7.1+rpt20260429
 fi
 cd $DIR/deps/libcamera
 

--- a/build_scripts/build-packages.sh
+++ b/build_scripts/build-packages.sh
@@ -198,6 +198,7 @@ for pkg in $PACKAGES; do
                             ros-$ROS_DISTRO-rplidar-ros, \
                             ros-$ROS_DISTRO-camera-info-manager, \
                             ros-$ROS_DISTRO-libcamera, \
+                            ros-$ROS_DISTRO-camera-ros, \
                             ros-$ROS_DISTRO-web-video-server, \
                             ros-$ROS_DISTRO-rosbag2, \
                             ros-$ROS_DISTRO-rosbag2-py, \

--- a/build_scripts/build-packages.sh
+++ b/build_scripts/build-packages.sh
@@ -207,7 +207,7 @@ for pkg in $PACKAGES; do
         if [ "$ROS_DISTRO" == "jazzy" ]; then
             PACKAGE_DEPS="$PACKAGE_DEPS, ros-$ROS_DISTRO-image-view"
             if [ $TARGET_ARCH == "arm64" ]; then
-                PACKAGE_DEPS="$PACKAGE_DEPS, ros-$ROS_DISTRO-libcamera (>= 1:0.5.0+drpi)"
+                PACKAGE_DEPS="$PACKAGE_DEPS, ros-$ROS_DISTRO-libcamera (>= 1:0.7.1+drpi)"
             else
                 PACKAGE_DEPS="$PACKAGE_DEPS, ros-$ROS_DISTRO-libcamera"
             fi

--- a/src/external/.rosinstall-humble
+++ b/src/external/.rosinstall-humble
@@ -1,4 +1,1 @@
-- git:
-    uri: https://github.com/christianrauch/camera_ros.git
-    local-name: camera_ros
-    version: main
+[]

--- a/src/external/.rosinstall-jazzy
+++ b/src/external/.rosinstall-jazzy
@@ -1,4 +1,1 @@
-- git:
-    uri: https://github.com/christianrauch/camera_ros.git
-    local-name: camera_ros
-    version: main
+[]

--- a/versions.json
+++ b/versions.json
@@ -3,6 +3,6 @@
 	"aws-deepracer-device-console": "2.0.196.3+community",
 	"aws-deepracer-sample-models": "2.0.9.0",
 	"aws-deepracer-util": "2.1.0.10+community",
-	"ros-jazzy-libcamera": "0.5.2+drpi",
+	"ros-jazzy-libcamera": "0.7.1+drpi",
 	"aws-deepracer-community-device-console": "2.2.12.0"
 }

--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,5 @@
 {
-	"aws-deepracer-core": "2.1.9.6+community",
+	"aws-deepracer-core": "2.1.9.7+community",
 	"aws-deepracer-device-console": "2.0.196.3+community",
 	"aws-deepracer-sample-models": "2.0.9.0",
 	"aws-deepracer-util": "2.1.0.10+community",


### PR DESCRIPTION
This pull request updates how the `camera_ros` package is managed in the build process. The main change is that `camera_ros` is no longer built from source for the `humble` and `jazzy` ROS distributions; instead, it is now installed as a binary package via the system package manager. This simplifies the build process and reduces maintenance overhead. Additionally, the `aws-deepracer-core` version has been incremented.

Dependency management changes:

* Removed the `camera_ros` source repository from `.rosinstall-humble` and `.rosinstall-jazzy`, so it is no longer fetched or built from source.
* Updated `build-packages.sh` to install the `camera_ros` package via the system package manager for relevant ROS distributions.
* Modified `build-core.sh` to exclude `camera_ros` from the list of packages built from source for `humble` and `jazzy`.

Version update:

* Bumped the `aws-deepracer-core` version in `versions.json` from `2.1.9.6+community` to `2.1.9.7+community`.