### PR TITLE
fix: re-optimize models when cached IR version mismatches current OpenVINO

### DIFF
--- a/src/aws-deepracer-model-optimizer-pkg/model_optimizer_pkg/model_optimizer_pkg/model_optimizer_node.py
+++ b/src/aws-deepracer-model-optimizer-pkg/model_optimizer_pkg/model_optimizer_pkg/model_optimizer_node.py
@@ -37,6 +37,7 @@ import os
 import subprocess
 import shlex
 import re
+import xml.etree.ElementTree as ET
 import rclpy
 from rclpy.parameter import ParameterType
 from rclpy.node import Node, ParameterDescriptor
@@ -234,6 +235,35 @@ class ModelOptimizerNode(Node):
         common_params[constants.ParamKeys.MODEL_NAME] = model_name
         return common_params
 
+    def get_xml_ir_version(self, xml_path):
+        """Parse a model.xml file to extract the OpenVINO IR version.
+
+        Args:
+            xml_path (str): Path to the model.xml file.
+
+        Returns:
+            int: IR version number from the <net> element's 'version' attribute,
+                 or -1 if the file cannot be parsed.
+        """
+        try:
+            tree = ET.parse(xml_path)
+            root = tree.getroot()
+            return int(root.get('version', '-1'))
+        except Exception as ex:
+            self.get_logger().warning(f"Could not parse IR version from {xml_path}: {ex}")
+            return -1
+
+    def get_expected_ir_version(self):
+        """Return the IR version expected for the current OpenVINO optimizer.
+
+        OpenVINO 2021 (mo_tf.py) produces IR v10.
+        OpenVINO 2022 and later (mo / ovc) produce IR v11.
+
+        Returns:
+            int: Expected IR version (10 for 2021, 11 for 2022+).
+        """
+        return 10 if constants.MODEL_OPTIMIZER_VERSION == 2021 else 11
+
     def run_optimizer_mo(self, mo_path, common_params, platform_parms):
         """Helper method that combines the common commands with the platform specific
            commands.
@@ -257,12 +287,20 @@ class ModelOptimizerNode(Node):
                 f"Model file {common_params[constants.ParamKeys.MODEL_PATH]} not found")
 
         # Check if model exists
-        if os.path.isfile(os.path.join(common_params[constants.ParamKeys.OUT_DIR],
-                                       f"{common_params[constants.ParamKeys.MODEL_NAME]}.xml")):
-            self.get_logger().info(
-                f"Cached model: {common_params[constants.ParamKeys.MODEL_NAME]}.xml")
-            return 0, os.path.join(common_params[constants.ParamKeys.OUT_DIR],
-                                   f"{common_params[constants.ParamKeys.MODEL_NAME]}.xml")
+        xml_path = os.path.join(common_params[constants.ParamKeys.OUT_DIR],
+                                f"{common_params[constants.ParamKeys.MODEL_NAME]}.xml")
+        if os.path.isfile(xml_path):
+            cached_ir_version = self.get_xml_ir_version(xml_path)
+            expected_ir_version = self.get_expected_ir_version()
+            if cached_ir_version == expected_ir_version:
+                self.get_logger().info(
+                    f"Cached model: {common_params[constants.ParamKeys.MODEL_NAME]}.xml "
+                    f"(IR v{cached_ir_version})")
+                return 0, xml_path
+            else:
+                self.get_logger().info(
+                    f"IR version mismatch: cached model has IR v{cached_ir_version}, "
+                    f"expected IR v{expected_ir_version}. Re-optimizing...")
 
         cmd = f"{mo_path}"
         # Construct the cli command
@@ -395,12 +433,20 @@ class ModelOptimizerNode(Node):
                 f"Model file {common_params[constants.ParamKeys.MODEL_PATH]} not found")
 
         # Check if model exists
-        if os.path.isfile(os.path.join(common_params[constants.ParamKeys.OUT_DIR],
-                                       f"{common_params[constants.ParamKeys.MODEL_NAME]}.xml")):
-            self.get_logger().info(
-                f"Cached model: {common_params[constants.ParamKeys.MODEL_NAME]}.xml")
-            return 0, os.path.join(common_params[constants.ParamKeys.OUT_DIR],
-                                   f"{common_params[constants.ParamKeys.MODEL_NAME]}.xml")
+        xml_path = os.path.join(common_params[constants.ParamKeys.OUT_DIR],
+                                f"{common_params[constants.ParamKeys.MODEL_NAME]}.xml")
+        if os.path.isfile(xml_path):
+            cached_ir_version = self.get_xml_ir_version(xml_path)
+            expected_ir_version = self.get_expected_ir_version()
+            if cached_ir_version == expected_ir_version:
+                self.get_logger().info(
+                    f"Cached model: {common_params[constants.ParamKeys.MODEL_NAME]}.xml "
+                    f"(IR v{cached_ir_version})")
+                return 0, xml_path
+            else:
+                self.get_logger().info(
+                    f"IR version mismatch: cached model has IR v{cached_ir_version}, "
+                    f"expected IR v{expected_ir_version}. Re-optimizing...")
 
         try:
             # Parse input names and shapes - exactly like TFLite does it

--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,5 @@
 {
-	"aws-deepracer-core": "2.1.9.7+community",
+	"aws-deepracer-core": "2.1.9.8+community",
 	"aws-deepracer-device-console": "2.0.196.3+community",
 	"aws-deepracer-sample-models": "2.0.9.0",
 	"aws-deepracer-util": "2.1.0.10+community",


### PR DESCRIPTION
Closes #66

## Problem

**DeepRacer Event Manager (DREM)** optimizes models in the cloud on **Ubuntu 20.04 / OpenVINO 2021**, producing a `model.xml` in the **IR v10** format. This pre-optimized XML is bundled into the model archive and installed onto the device alongside `model.pb`.

When the model is loaded on a device running **Ubuntu 24.04 / OpenVINO 2024**, `model_optimizer_node.py` finds the existing `model.xml` and returns it as a cache hit — skipping re-optimization. OpenVINO 2024 cannot reliably run inference on IR v10 files, causing failures at runtime.

| OpenVINO version | IR version | Converter |
|---|---|---|
| 2021.x | v10 | `mo_tf.py` |
| 2022.x+ | v11 | `mo` / `ovc` |

The cache check was purely file-existence based with no awareness of which OpenVINO version generated the cached XML.

## Fix

Changes in `model_optimizer_node.py`:

- **`get_xml_ir_version(xml_path)`** — parses the `version` attribute of the `<net>` root element in the cached `model.xml` using `xml.etree.ElementTree` (stdlib, no new dependency). Returns `-1` on failure, which safely triggers re-optimization.
- **`get_expected_ir_version()`** — maps `MODEL_OPTIMIZER_VERSION == 2021` → IR v10, all later versions → IR v11.
- **`run_optimizer_mo`** and **`run_optimizer_ov`** — both cache checks now validate the IR version before returning early. A mismatch logs a warning and falls through to re-optimize with the local toolchain.

## Example log output

**Cache hit (versions match):**
```
[model_optimizer_node]: Cached model: my_model/model.xml (IR v11)
```

**Re-optimization triggered (DREM cloud-optimized model on Ubuntu 24.04):**
```
[model_optimizer_node]: IR version mismatch: cached model has IR v10, expected IR v11. Re-optimizing...
```