### PR TITLE
Startup configuration via config.json

### DIFF
--- a/.devcontainer/foxy-amd64/devcontainer.json
+++ b/.devcontainer/foxy-amd64/devcontainer.json
@@ -18,7 +18,8 @@
     "mounts": [
         "source=deepracer-ros-bashhistory,target=/commandhistory,type=volume",
         "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind",
-        "source=${localEnv:HOME}/.aws,target=/home/${localEnv:USER}/.aws,type=bind"
+        "source=${localEnv:HOME}/.aws,target=/home/${localEnv:USER}/.aws,type=bind",
+        "source=${localWorkspaceFolder}/../deepracer-custom-console,target=/workspaces/deepracer-custom-console,type=bind,consistency=cached"
     ],
     "customizations": {
         "vscode": {

--- a/.devcontainer/humble/devcontainer.json
+++ b/.devcontainer/humble/devcontainer.json
@@ -19,7 +19,8 @@
         "source=deepracer-ros-bashhistory,target=/commandhistory,type=volume",
         "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind",
         "source=${localEnv:HOME}/.aws,target=/home/${localEnv:USER}/.aws,type=bind",
-        "source=${localEnv:HOME}/.gnupg,target=/home/${localEnv:USER}/.gnupg,type=bind"
+        "source=${localEnv:HOME}/.gnupg,target=/home/${localEnv:USER}/.gnupg,type=bind",
+        "source=${localWorkspaceFolder}/../deepracer-custom-console,target=/workspaces/deepracer-custom-console,type=bind,consistency=cached"
     ],
     "customizations": {
         "vscode": {

--- a/.devcontainer/noble/devcontainer.json
+++ b/.devcontainer/noble/devcontainer.json
@@ -19,7 +19,8 @@
         "source=deepracer-ros-bashhistory,target=/commandhistory,type=volume",
         "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind",
         "source=${localEnv:HOME}/.aws,target=/home/${localEnv:USER}/.aws,type=bind",
-        "source=${localEnv:HOME}/.gnupg,target=/home/${localEnv:USER}/.gnupg,type=bind"
+        "source=${localEnv:HOME}/.gnupg,target=/home/${localEnv:USER}/.gnupg,type=bind",
+        "source=${localWorkspaceFolder}/../deepracer-custom-console,target=/workspaces/deepracer-custom-console,type=bind,consistency=cached"
     ],
     "customizations": {
         "vscode": {

--- a/build_scripts/build-packages.sh
+++ b/build_scripts/build-packages.sh
@@ -189,7 +189,7 @@ for pkg in $PACKAGES; do
 
     if [ "$pkg" == "aws-deepracer-core" ]; then
         VERSION=$(jq -r ".[\"aws-deepracer-core\"]" $DIR/versions.json)-$(lsb_release -cs)
-        PACKAGE_DEPS="gnupg, python3-apt, python3-psutil, libomp5, ros-$ROS_DISTRO-ros-core, \
+        PACKAGE_DEPS="jq, gnupg, python3-apt, python3-psutil, libomp5, ros-$ROS_DISTRO-ros-core, \
                         ros-$ROS_DISTRO-image-transport, ros-$ROS_DISTRO-compressed-image-transport, \
                         ros-$ROS_DISTRO-pybind11-vendor, ros-$ROS_DISTRO-cv-bridge"
         if [ "$ROS_DISTRO" == "humble" ] || [ "$ROS_DISTRO" == "jazzy" ]; then
@@ -225,7 +225,7 @@ for pkg in $PACKAGES; do
         sed -i 's/ExecStop=\/opt\/aws\/deepracer\/util\/otg_eth.sh stop/KillSignal=2/' etc/systemd/system/deepracer-core.service
         rm -rf opt/aws/deepracer/lib/*
         cp $DIR/build_scripts/files/common/start_ros.sh opt/aws/deepracer/
-        cp $DIR/build_scripts/files/common/logging.conf opt/aws/deepracer/
+        cp $DIR/build_scripts/files/common/config.json opt/aws/deepracer/
         cp $DIR/build_scripts/files/common/aws-deepracer-core-prerm DEBIAN/prerm
         cp $DIR/build_scripts/files/common/aws-deepracer-core-conffiles DEBIAN/conffiles
         cp -r $DIR/install/* opt/aws/deepracer/lib/

--- a/build_scripts/files/common/aws-deepracer-core-conffiles
+++ b/build_scripts/files/common/aws-deepracer-core-conffiles
@@ -1,1 +1,1 @@
-/opt/aws/deepracer/logging.conf
+/opt/aws/deepracer/config.json

--- a/build_scripts/files/common/config.json
+++ b/build_scripts/files/common/config.json
@@ -1,0 +1,13 @@
+{
+  "logging": {
+    "mode": "always",
+    "provider": "sqlite3"
+  },
+  "camera": {
+    "mode": "auto"
+  },
+  "inference": {
+    "engine": "auto",
+    "device": "auto"
+  }
+}

--- a/build_scripts/files/common/logging.conf
+++ b/build_scripts/files/common/logging.conf
@@ -1,2 +1,0 @@
-provider=sqlite3
-mode=always

--- a/build_scripts/files/common/start_ros.sh
+++ b/build_scripts/files/common/start_ros.sh
@@ -26,17 +26,49 @@ else
     echo "No OpenVINO found!"
 fi
 
-# Determine which ineference engine and device to use
-# Priority for MYRIAD > CPU (ROS2 Foxy x86_64 only) > TFLITE
-MYRIAD=$(lsusb | grep "Intel Movidius MyriadX")
-if [ -n "${MYRIAD}" ]; then
-    INFERENCE_ENGINE='inference_engine:=OV'
-    INFERENCE_DEVICE='inference_device:=MYRIAD'
-elif [ "$(uname -m)" == "x86_64" ]; then
-    INFERENCE_ENGINE='inference_engine:=OV'
-    INFERENCE_DEVICE='inference_device:=CPU'
+# Require jq for config.json parsing
+if ! command -v jq &>/dev/null; then
+    echo "ERROR: jq is not installed. Install it with: sudo apt-get install -y jq" >&2
+    exit 1
+fi
+
+# Read configuration overrides from config.json
+CONFIG_FILE='/opt/aws/deepracer/config.json'
+if [ -f "${CONFIG_FILE}" ]; then
+    CFG_LOGGING_MODE=$(jq -r '.logging.mode // empty' "${CONFIG_FILE}" 2>/dev/null)
+    CFG_LOGGING_PROVIDER=$(jq -r '.logging.provider // empty' "${CONFIG_FILE}" 2>/dev/null)
+    CFG_CAMERA_MODE=$(jq -r '.camera.mode // empty' "${CONFIG_FILE}" 2>/dev/null)
+    CFG_INFERENCE_ENGINE=$(jq -r '.inference.engine // empty' "${CONFIG_FILE}" 2>/dev/null)
+    CFG_INFERENCE_DEVICE=$(jq -r '.inference.device // empty' "${CONFIG_FILE}" 2>/dev/null)
 else
-    INFERENCE_ENGINE='inference_engine:=TFLITE'
+    CFG_LOGGING_MODE=''
+    CFG_LOGGING_PROVIDER=''
+    CFG_CAMERA_MODE=''
+    CFG_INFERENCE_ENGINE=''
+    CFG_INFERENCE_DEVICE=''
+fi
+
+# Determine inference engine and device
+# Config overrides auto-detection; auto-detection priority: MYRIAD > OV/CPU (x86_64) > TFLITE
+if [ -n "${CFG_INFERENCE_ENGINE}" ] && [ "${CFG_INFERENCE_ENGINE}" != "auto" ]; then
+    INFERENCE_ENGINE="inference_engine:=${CFG_INFERENCE_ENGINE}"
+    if [ -n "${CFG_INFERENCE_DEVICE}" ] && [ "${CFG_INFERENCE_DEVICE}" != "auto" ]; then
+        INFERENCE_DEVICE="inference_device:=${CFG_INFERENCE_DEVICE}"
+    else
+        INFERENCE_DEVICE=''
+    fi
+else
+    MYRIAD=$(lsusb | grep "Intel Movidius MyriadX")
+    if [ -n "${MYRIAD}" ]; then
+        INFERENCE_ENGINE='inference_engine:=OV'
+        INFERENCE_DEVICE='inference_device:=MYRIAD'
+    elif [ "$(uname -m)" == "x86_64" ]; then
+        INFERENCE_ENGINE='inference_engine:=OV'
+        INFERENCE_DEVICE='inference_device:=CPU'
+    else
+        INFERENCE_ENGINE='inference_engine:=TFLITE'
+        INFERENCE_DEVICE=''
+    fi
 fi
 
 # No support for battery sensor on Raspberry Pi
@@ -47,20 +79,18 @@ else
 fi
 
 # Determine camera mode
-if [ "$ROS_DISTRO" == "foxy" ]; then
+# Config overrides auto-detection; auto-detection: foxy -> legacy, others -> modern
+if [ -n "${CFG_CAMERA_MODE}" ] && [ "${CFG_CAMERA_MODE}" != "auto" ]; then
+    CAMERA_MODE="camera_mode:=${CFG_CAMERA_MODE}"
+elif [ "$ROS_DISTRO" == "foxy" ]; then
     CAMERA_MODE=''
 else
     CAMERA_MODE='camera_mode:=modern'
 fi
 
-# Read in logging configuration
-if [ -f /opt/aws/deepracer/logging.conf ]; then
-    LOGGING_MODE="logging_mode:=$(cat /opt/aws/deepracer/logging.conf | grep mode | cut -d'=' -f2 | tr -d '[:space:]')"
-    LOGGING_PROVIDER="logging_provider:=$(cat /opt/aws/deepracer/logging.conf | grep provider | cut -d'=' -f2 | tr -d '[:space:]')"
-else
-    LOGGING_MODE='logging_mode:=usbonly'
-    LOGGING_PROVIDER='logging_provider:=sqlite3'
-fi
+# Determine logging configuration
+LOGGING_MODE="logging_mode:=${CFG_LOGGING_MODE:-usbonly}"
+LOGGING_PROVIDER="logging_provider:=${CFG_LOGGING_PROVIDER:-sqlite3}"
 
 # Check if the LiDAR is connected via UART
 CP210X=$(lsusb | grep "CP210x UART Bridge")
@@ -72,4 +102,9 @@ else
     echo "RPLIDAR / UART Bridge not found!"
 fi
 
-ros2 launch deepracer_launcher deepracer_launcher.py ${INFERENCE_ENGINE} ${INFERENCE_DEVICE} ${BATTERY_DUMMY} ${LOGGING_MODE} ${LOGGING_PROVIDER} ${CAMERA_MODE} ${RPLIDAR}
+CMD="ros2 launch deepracer_launcher deepracer_launcher.py"
+for ARG in "${INFERENCE_ENGINE}" "${INFERENCE_DEVICE}" "${BATTERY_DUMMY}" "${LOGGING_MODE}" "${LOGGING_PROVIDER}" "${CAMERA_MODE}" "${RPLIDAR}"; do
+    [ -n "${ARG}" ] && CMD="${CMD} ${ARG}"
+done
+echo "==> ${CMD}"
+exec ${CMD}

--- a/install_scripts/aws-24.04/install-remote.sh
+++ b/install_scripts/aws-24.04/install-remote.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+TARGET_HOST="${1:?Usage: $0 <target-host> [ssh-user]}"
+SSH_USER="${2:-deepracer}"
+
+SSH_CMD="ssh ${SSH_USER}@${TARGET_HOST}"
+
+echo "==> Deploying to ${SSH_USER}@${TARGET_HOST}"
+
+# Stop service
+echo "Stopping deepracer-core..."
+${SSH_CMD} "sudo systemctl stop deepracer-core"
+
+# Sync install/ to the target (only changed files are transferred)
+echo "Syncing install/ to ${TARGET_HOST}..."
+rsync -a --rsync-path='sudo rsync' \
+    "${REPO_DIR}/install/" \
+    "${SSH_USER}@${TARGET_HOST}:/opt/aws/deepracer/lib/"
+
+# Sync start_ros.sh
+echo "Syncing start_ros.sh..."
+rsync -a --rsync-path='sudo rsync' \
+    "${REPO_DIR}/build_scripts/files/common/start_ros.sh" \
+    "${SSH_USER}@${TARGET_HOST}:/opt/aws/deepracer/start_ros.sh"
+
+# Disable CSRF protection for cross-origin dev access
+echo "Disabling CSRF..."
+${SSH_CMD} "sudo sed -i 's/REMEMBER_COOKIE_SECURE=True)/REMEMBER_COOKIE_SECURE=True,\n    WTF_CSRF_ENABLED=False)/' /opt/aws/deepracer/lib/webserver_pkg/lib/python3.*/site-packages/webserver_pkg/webserver.py"
+
+# Restart deepracer
+echo "Restarting deepracer-core..."
+${SSH_CMD} "sudo systemctl restart deepracer-core"
+
+echo "==> Done. Deployed to ${SSH_USER}@${TARGET_HOST}"

--- a/src/aws-deepracer-webserver-pkg/webserver_pkg/webserver_pkg/car_config_api.py
+++ b/src/aws-deepracer-webserver-pkg/webserver_pkg/webserver_pkg/car_config_api.py
@@ -1,0 +1,280 @@
+#################################################################################
+#   Copyright AWS DeepRacer Community. All Rights Reserved.                     #
+#                                                                               #
+#   Licensed under the Apache License, Version 2.0 (the "License").             #
+#   You may not use this file except in compliance with the License.            #
+#   You may obtain a copy of the License at                                     #
+#                                                                               #
+#       http://www.apache.org/licenses/LICENSE-2.0                              #
+#                                                                               #
+#   Unless required by applicable law or agreed to in writing, software         #
+#   distributed under the License is distributed on an "AS IS" BASIS,           #
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    #
+#   See the License for the specific language governing permissions and         #
+#   limitations under the License.                                              #
+#################################################################################
+
+"""
+car_config_api.py
+
+API for reading and writing vehicle configuration settings. Settings are
+persisted to /opt/aws/deepracer/config.json and are applied on the next
+service restart via start_ros.sh.
+"""
+
+import json
+import os
+
+from flask import (Blueprint,
+                   jsonify,
+                   request)
+
+from webserver_pkg import webserver_publisher_node
+
+CAR_CONFIG_API_BLUEPRINT = Blueprint("car_config_api", __name__)
+
+CONFIG_FILE_PATH = "/opt/aws/deepracer/config.json"
+
+# Valid options for each setting
+VALID_LOGGING_MODES = ["Never", "USBOnly", "Always"]
+VALID_INFERENCE_ENGINES = ["TFLITE", "OV"]
+VALID_INFERENCE_DEVICES = {
+    "TFLITE": ["CPU"],
+    "OV": ["CPU", "GPU", "MYRIAD"]
+}
+VALID_CAMERA_MODES = ["legacy", "modern"]
+VALID_LOGGING_PROVIDERS = ["sqlite3", "mcap"]
+
+DEFAULT_CONFIG = {
+    "logging": {
+        "mode": "always",
+        "provider": "sqlite3"
+    },
+    "camera": {
+        "mode": "auto"
+    },
+    "inference": {
+        "engine": "auto",
+        "device": "auto"
+    }
+}
+
+
+def _get_ros_distro():
+    """Return the current ROS_DISTRO environment variable value."""
+    return os.environ.get("ROS_DISTRO", "")
+
+
+def _is_myriad_present():
+    """Return True if an Intel Movidius Myriad X device is detected via lsusb."""
+    import subprocess
+    try:
+        result = subprocess.run(["lsusb"], capture_output=True, text=True, timeout=5)
+        return "Intel Movidius MyriadX" in result.stdout
+    except Exception:
+        return False
+
+
+def _get_capabilities():
+    """Build the capabilities matrix based on the current system.
+
+    Returns:
+        dict: Available options for each configurable setting.
+    """
+    import platform
+    is_foxy = _get_ros_distro() == "foxy"
+    is_x86 = platform.machine() == "x86_64"
+
+    ov_devices = []
+    if is_x86:
+        ov_devices.append("CPU")
+    if is_foxy:
+        ov_devices.append("GPU")
+    if _is_myriad_present():
+        ov_devices.append("MYRIAD")
+
+    inference_devices = dict(VALID_INFERENCE_DEVICES)
+    inference_devices["OV"] = ov_devices
+
+    # Only advertise OV if at least one device is available
+    inference_engines = [e for e in VALID_INFERENCE_ENGINES if e != "OV" or ov_devices]
+
+    return {
+        "camera_modes": ["legacy"] if is_foxy else ["legacy", "modern"],
+        "logging_modes": ["Never", "USBOnly", "Always"],
+        "logging_providers": ["sqlite3"] if is_foxy else ["sqlite3", "mcap"],
+        "inference_engines": inference_engines,
+        "inference_devices": inference_devices
+    }
+
+
+def _deep_merge(base, override):
+    """Recursively merge override into base, only accepting known keys.
+
+    Args:
+        base (dict): Base dictionary with known structure.
+        override (dict): Values to merge in.
+
+    Returns:
+        dict: Merged dictionary.
+    """
+    result = {k: (v.copy() if isinstance(v, dict) else v) for k, v in base.items()}
+    for key, value in override.items():
+        if key not in result:
+            continue  # ignore unknown top-level keys
+        if isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = _deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def _read_config():
+    """Read the config.json file, falling back to defaults for missing keys.
+
+    Returns:
+        dict: Current configuration.
+    """
+    import copy
+    config = copy.deepcopy(DEFAULT_CONFIG)
+    if os.path.exists(CONFIG_FILE_PATH):
+        try:
+            with open(CONFIG_FILE_PATH, "r") as f:
+                stored = json.load(f)
+            config = _deep_merge(config, stored)
+        except (json.JSONDecodeError, IOError) as ex:
+            webserver_publisher_node.get_webserver_node().get_logger().warning(
+                f"Failed to read car config, using defaults: {ex}"
+            )
+    return config
+
+
+def _write_config(config):
+    """Persist the config dict to config.json.
+
+    Args:
+        config (dict): Configuration to write.
+    """
+    os.makedirs(os.path.dirname(CONFIG_FILE_PATH), exist_ok=True)
+    with open(CONFIG_FILE_PATH, "w") as f:
+        json.dump(config, f, indent=2)
+
+
+def _validate_config(data, capabilities):
+    """Validate the incoming config values against the capabilities matrix.
+
+    Args:
+        data (dict): Incoming nested config values to validate.
+        capabilities (dict): Current system capabilities.
+
+    Returns:
+        tuple: (is_valid: bool, error_message: str | None)
+    """
+    logging_data = data.get("logging", {})
+    camera_data = data.get("camera", {})
+    inference_data = data.get("inference", {})
+
+    if "mode" in logging_data:
+        mode = logging_data["mode"]
+        valid_lower = [m.lower() for m in VALID_LOGGING_MODES]
+        if mode.lower() not in valid_lower:
+            return False, f"Invalid logging.mode '{mode}'. Valid values: {VALID_LOGGING_MODES}"
+
+    if "provider" in logging_data:
+        provider = logging_data["provider"]
+        if provider not in capabilities["logging_providers"]:
+            return False, (
+                f"logging.provider '{provider}' is not supported on this system. "
+                f"Available: {capabilities['logging_providers']}"
+            )
+
+    if "mode" in camera_data:
+        mode = camera_data["mode"]
+        # 'auto' means auto-detect, which is always valid
+        if mode != "auto" and mode not in capabilities["camera_modes"]:
+            return False, (
+                f"camera.mode '{mode}' is not supported on this system. "
+                f"Available: {capabilities['camera_modes']} or 'auto'"
+            )
+
+    if "engine" in inference_data:
+        engine = inference_data["engine"]
+        # 'auto' means auto-detect
+        if engine != "auto" and engine not in capabilities["inference_engines"]:
+            return False, f"Invalid inference.engine '{engine}'. Valid values: {VALID_INFERENCE_ENGINES} or 'auto'"
+
+    if "device" in inference_data:
+        device = inference_data["device"]
+        engine = inference_data.get("engine", "auto")
+        if device != "auto" and engine != "auto":
+            allowed_devices = VALID_INFERENCE_DEVICES.get(engine, [])
+            if device not in allowed_devices:
+                return False, (
+                    f"inference.device '{device}' is not valid for engine '{engine}'. "
+                    f"Allowed: {allowed_devices} or 'auto'"
+                )
+        elif device != "auto" and engine == "auto":
+            all_devices = [d for devices in VALID_INFERENCE_DEVICES.values() for d in devices]
+            if device not in all_devices:
+                return False, f"Invalid inference.device '{device}'"
+
+    return True, None
+
+
+@CAR_CONFIG_API_BLUEPRINT.route("/api/car_config", methods=["GET"])
+def get_car_config():
+    """API to get the current vehicle configuration and available options.
+
+    Returns:
+        dict: JSON with success status, current config, and capabilities matrix.
+    """
+    try:
+        config = _read_config()
+        capabilities = _get_capabilities()
+        return jsonify({
+            "success": True,
+            "config": config,
+            "capabilities": capabilities
+        })
+    except Exception as ex:
+        webserver_publisher_node.get_webserver_node().get_logger().error(
+            f"Failed to get car config: {ex}"
+        )
+        return jsonify({"success": False, "reason": str(ex)})
+
+
+@CAR_CONFIG_API_BLUEPRINT.route("/api/car_config", methods=["POST"])
+def set_car_config():
+    """API to update vehicle configuration settings.
+
+    The new settings are persisted to config.json and will take effect
+    on the next service restart.
+
+    Returns:
+        dict: JSON with success status and the updated config.
+    """
+    try:
+        data = request.get_json(silent=True)
+        if not data:
+            return jsonify({"success": False, "reason": "No JSON data provided"})
+
+        capabilities = _get_capabilities()
+        is_valid, error = _validate_config(data, capabilities)
+        if not is_valid:
+            return jsonify({"success": False, "reason": error})
+
+        current = _read_config()
+        current = _deep_merge(current, data)
+
+        _write_config(current)
+
+        webserver_publisher_node.get_webserver_node().get_logger().info(
+            "Car configuration updated. Restart required for changes to take effect."
+        )
+        return jsonify({"success": True, "config": current})
+
+    except Exception as ex:
+        webserver_publisher_node.get_webserver_node().get_logger().error(
+            f"Failed to set car config: {ex}"
+        )
+        return jsonify({"success": False, "reason": str(ex)})

--- a/src/aws-deepracer-webserver-pkg/webserver_pkg/webserver_pkg/webserver.py
+++ b/src/aws-deepracer-webserver-pkg/webserver_pkg/webserver_pkg/webserver.py
@@ -30,6 +30,7 @@ from flask import Flask
 from flask_wtf.csrf import CSRFProtect
 
 from webserver_pkg.calibration import CALIBRATION_BLUEPRINT
+from webserver_pkg.car_config_api import CAR_CONFIG_API_BLUEPRINT
 from webserver_pkg.device_info_api import DEVICE_INFO_API_BLUEPRINT
 from webserver_pkg.login import LOGIN_BLUEPRINT
 from webserver_pkg.led_api import LED_API_BLUEPRINT
@@ -49,6 +50,7 @@ CORS(app)
 csrf = CSRFProtect()
 # Initialize the application with CSRF and register all the API blueprints.
 csrf.init_app(app)
+app.register_blueprint(CAR_CONFIG_API_BLUEPRINT)
 app.register_blueprint(VEHICLE_LOGS_BLUEPRINT)
 app.register_blueprint(VEHICLE_CONTROL_BLUEPRINT)
 app.register_blueprint(WIFI_SETTINGS_BLUEPRINT)


### PR DESCRIPTION
## Summary

Replaces the old flat `logging.conf` file with a structured `config.json` that controls logging, camera mode, and inference engine/device selection. A new Flask API (`/api/car_config`) exposes the configuration to the console, enabling the **Car Settings** UI added in [deepracer-custom-console#102](https://github.com/aws-deepracer-community/deepracer-custom-console/pull/102).

---

## Changes

### `config.json` — new unified configuration file

`/opt/aws/deepracer/config.json` replaces the old `logging.conf` key=value file. Structure:

```json
{
  "logging":   { "mode": "always", "provider": "sqlite3" },
  "camera":    { "mode": "auto" },
  "inference": { "engine": "auto", "device": "auto" }
}
```

The file is a `dpkg` conffile (preserved across package upgrades).

### `start_ros.sh` — config-driven launch

The startup script now:
- Parses `config.json` with `jq` (added as a package dependency).
- Uses config values to set logging mode/provider, camera mode, and inference engine/device — falling back to the previous auto-detection logic when a field is `"auto"` or absent.
- Builds the `ros2 launch` command explicitly, skipping empty args, and `exec`s it (cleaner process tree).
- Emits a clear error and exits if `jq` is not installed.

Auto-detection fallback priority (unchanged):
- **Inference**: Myriad X VPU → OV/CPU (x86_64) → TFLite (ARM)
- **Camera**: `legacy` (ROS Foxy) → `modern` (Humble/Jazz/Noble)

### `/api/car_config` — new REST endpoint

`car_config_api.py` (registered as a Flask Blueprint) provides:

| Method | Path | Description |
|---|---|---|
| `GET` | `/api/car_config` | Returns current config + system capabilities matrix |
| `POST` | `/api/car_config` | Validates and persists updated config values |

The `capabilities` payload advertises which options are available on the running hardware (e.g. OV devices, camera modes, logging providers), so the console UI can render only valid choices.

Input validation rejects unknown engines/devices/modes against the capabilities matrix. Deep-merge on write ensures partial updates are safe.

### Dev container — side-by-side workspace

All three devcontainer variants (`foxy-amd64`, `humble`, `noble`) now mount the sibling `deepracer-custom-console` repo into `/workspaces/deepracer-custom-console`, enabling the multi-root workspace (`deepracer-custom-car.code-workspace`) to be used for full-stack development without cloning separately.

### `install-remote.sh` — quick deploy helper

New script `install_scripts/aws-24.04/install-remote.sh` syncs the built `install/` tree and `start_ros.sh` to a target host over SSH/rsync without a full package rebuild, for rapid iteration during development.
