### PR TITLE
feat: Add camera orientation (rotation) support for libcamera mode

### DIFF
--- a/build_scripts/files/common/start_ros.sh
+++ b/build_scripts/files/common/start_ros.sh
@@ -38,6 +38,7 @@ if [ -f "${CONFIG_FILE}" ]; then
     CFG_LOGGING_MODE=$(jq -r '.logging.mode // empty' "${CONFIG_FILE}" 2>/dev/null)
     CFG_LOGGING_PROVIDER=$(jq -r '.logging.provider // empty' "${CONFIG_FILE}" 2>/dev/null)
     CFG_CAMERA_MODE=$(jq -r '.camera.mode // empty' "${CONFIG_FILE}" 2>/dev/null)
+    CFG_CAMERA_ORIENTATION=$(jq -r '.camera.orientation // 0' "${CONFIG_FILE}" 2>/dev/null)
     CFG_GRAY_OVERLAY=$(jq -r '.camera.enable_gray_overlay // false' "${CONFIG_FILE}" 2>/dev/null)
     CFG_INFERENCE_ENGINE=$(jq -r '.inference.engine // empty' "${CONFIG_FILE}" 2>/dev/null)
     CFG_INFERENCE_DEVICE=$(jq -r '.inference.device // empty' "${CONFIG_FILE}" 2>/dev/null)
@@ -46,6 +47,7 @@ else
     CFG_LOGGING_MODE=''
     CFG_LOGGING_PROVIDER=''
     CFG_CAMERA_MODE=''
+    CFG_CAMERA_ORIENTATION='0'
     CFG_GRAY_OVERLAY='false'
     CFG_INFERENCE_ENGINE=''
     CFG_INFERENCE_DEVICE=''
@@ -92,6 +94,16 @@ else
     CAMERA_MODE='camera_mode:=modern'
 fi
 
+# Determine camera orientation for modern/libcamera mode only.
+# In auto mode we keep orientation hidden in UI, so only explicit modern mode enables this.
+case "${CFG_CAMERA_ORIENTATION}" in
+    180) CAMERA_ORIENTATION="camera_orientation:=180" ;;
+    *) CAMERA_ORIENTATION="camera_orientation:=0" ;;
+esac
+if [ "${CFG_CAMERA_MODE}" != "modern" ]; then
+    CAMERA_ORIENTATION=''
+fi
+
 # Determine logging configuration
 LOGGING_MODE="logging_mode:=${CFG_LOGGING_MODE:-usbonly}"
 LOGGING_PROVIDER="logging_provider:=${CFG_LOGGING_PROVIDER:-sqlite3}"
@@ -120,7 +132,7 @@ else
 fi
 
 CMD="ros2 launch deepracer_launcher deepracer_launcher.py"
-for ARG in "${INFERENCE_ENGINE}" "${INFERENCE_DEVICE}" "${BATTERY_DUMMY}" "${LOGGING_MODE}" "${LOGGING_PROVIDER}" "${CAMERA_MODE}" "${STEERING_MODE}" "${RPLIDAR}" "${GRAY_OVERLAY}"; do
+for ARG in "${INFERENCE_ENGINE}" "${INFERENCE_DEVICE}" "${BATTERY_DUMMY}" "${LOGGING_MODE}" "${LOGGING_PROVIDER}" "${CAMERA_MODE}" "${CAMERA_ORIENTATION}" "${STEERING_MODE}" "${RPLIDAR}" "${GRAY_OVERLAY}"; do
     [ -n "${ARG}" ] && CMD="${CMD} ${ARG}"
 done
 echo "==> ${CMD}"

--- a/src/aws-deepracer-launcher/deepracer_launcher/launch/deepracer_launcher.py
+++ b/src/aws-deepracer-launcher/deepracer_launcher/launch/deepracer_launcher.py
@@ -33,6 +33,7 @@ def launch_setup(context, *args, **kwargs):
 
     camera_mode = LaunchConfiguration('camera_mode').perform(context)
     camera_index = int(LaunchConfiguration('camera_index').perform(context))
+    camera_orientation = int(LaunchConfiguration('camera_orientation').perform(context))
     fps = int(LaunchConfiguration('camera_fps').perform(context))
     resize_images = str2bool(LaunchConfiguration('camera_resize').perform(context))
     resolution = resize_images and [160, 120] or [640, 480]
@@ -52,6 +53,7 @@ def launch_setup(context, *args, **kwargs):
         # Camera configuration
         camera_params = {'width': resolution[0],
                          'height': resolution[1],
+                         'orientation': camera_orientation,
                          'FrameDurationLimits': [math.floor(1e6 / fps), math.ceil(1e6 / fps)],
                          'use_node_time': True}
 
@@ -355,6 +357,10 @@ def generate_launch_description():
                 name="camera_index",
                 default_value="0",
                 description="Index of the camera to use, applicable to modern camera_mode only"),
+            DeclareLaunchArgument(
+                name="camera_orientation",
+                default_value="0",
+                description="Camera orientation in degrees, applicable to modern camera_mode only"),
             DeclareLaunchArgument(
                 name="rplidar",
                 default_value="True",

--- a/src/aws-deepracer-webserver-pkg/webserver_pkg/webserver_pkg/car_config_api.py
+++ b/src/aws-deepracer-webserver-pkg/webserver_pkg/webserver_pkg/car_config_api.py
@@ -53,6 +53,7 @@ DEFAULT_CONFIG = {
     },
     "camera": {
         "mode": "auto",
+        "orientation": 0,
         "enable_gray_overlay": False
     },
     "inference": {
@@ -106,6 +107,7 @@ def _get_capabilities():
 
     return {
         "camera_modes": ["legacy"] if is_foxy else ["legacy", "modern"],
+        "camera_orientations": [0] if is_foxy else [0, 180],
         "logging_modes": ["Never", "USBOnly", "Always"],
         "logging_providers": ["sqlite3"] if is_foxy else ["sqlite3", "mcap"],
         "inference_engines": inference_engines,
@@ -204,6 +206,15 @@ def _validate_config(data, capabilities):
                 f"camera.mode '{mode}' is not supported on this system. "
                 f"Available: {capabilities['camera_modes']} or 'auto'"
             )
+
+    if "orientation" in camera_data:
+        orientation = camera_data["orientation"]
+        if not isinstance(orientation, int):
+            return False, "camera.orientation must be an integer"
+        if orientation not in [0, 180]:
+            return False, "camera.orientation must be one of: 0, 180"
+        if not capabilities.get("camera_orientations"):
+            return False, "camera.orientation is not supported on this system"
 
     if "engine" in inference_data:
         engine = inference_data["engine"]

--- a/versions.json
+++ b/versions.json
@@ -1,8 +1,8 @@
 {
-	"aws-deepracer-core": "2.3.0.2+community",
+	"aws-deepracer-core": "2.3.0.3+community",
 	"aws-deepracer-device-console": "2.0.196.3+community",
 	"aws-deepracer-sample-models": "2.0.9.0",
 	"aws-deepracer-util": "2.1.0.10+community",
 	"ros-jazzy-libcamera": "0.7.1+drpi",
-	"aws-deepracer-community-device-console": "2.3.0.4+97b42764"
+	"aws-deepracer-community-device-console": "2.3.0.7+696ee11e"
 }


### PR DESCRIPTION
## Summary

Adds support for configuring camera rotation (0° or 180°) when using the modern libcamera driver. The orientation is persisted in the car config JSON and passed through to the ROS launcher as a camera parameter.

## Changes

### `build_scripts/files/common/start_ros.sh`
- Reads `CFG_CAMERA_ORIENTATION` from the config file (defaults to `0`)
- Converts the value to a `camera_orientation:=<value>` launch argument
- Only passes the argument when `CFG_CAMERA_MODE` is `modern` (orientation has no effect for legacy/V4L2)
- Adds `${CAMERA_ORIENTATION}` to the `ros2 launch` command

### `src/aws-deepracer-launcher/deepracer_launcher/launch/deepracer_launcher.py`
- Declares `camera_orientation` as a new launch argument (default `0`)
- Passes `orientation` into the `camera_params` dict for the `camera_ros` node when using modern mode

### `src/aws-deepracer-webserver-pkg/webserver_pkg/webserver_pkg/car_config_api.py`
- Adds `orientation: 0` to `DEFAULT_CONFIG` under `camera`
- Exposes `camera_orientations` in the capabilities response (`[0]` for Foxy, `[0, 180]` for Humble and later)
- Validates `camera.orientation` in `_validate_config`: must be an integer, one of `[0, 180]`, and only allowed when the capability is available
