### PR TITLE
feat: add BMI160 IMU package (imu_pkg)

### DIFF
--- a/build_scripts/files/common/start_ros.sh
+++ b/build_scripts/files/common/start_ros.sh
@@ -43,6 +43,11 @@ if [ -f "${CONFIG_FILE}" ]; then
     CFG_INFERENCE_ENGINE=$(jq -r '.inference.engine // empty' "${CONFIG_FILE}" 2>/dev/null)
     CFG_INFERENCE_DEVICE=$(jq -r '.inference.device // empty' "${CONFIG_FILE}" 2>/dev/null)
     CFG_STEERING_MODE=$(jq -r '.steering.mode // empty' "${CONFIG_FILE}" 2>/dev/null)
+    CFG_IMU_ENABLED=$(jq -r '.imu.enabled // false' "${CONFIG_FILE}" 2>/dev/null)
+    CFG_IMU_CRASH_ENABLED=$(jq -r '.imu.crash_enabled // false' "${CONFIG_FILE}" 2>/dev/null)
+    CFG_IMU_CRASH_THRESHOLD=$(jq -r '.imu.crash_threshold_g // 3.0' "${CONFIG_FILE}" 2>/dev/null)
+    CFG_IMU_PICKUP_ENABLED=$(jq -r '.imu.pickup_enabled // false' "${CONFIG_FILE}" 2>/dev/null)
+    CFG_IMU_PICKUP_THRESHOLD=$(jq -r '.imu.pickup_threshold_g // 0.5' "${CONFIG_FILE}" 2>/dev/null)
 else
     CFG_LOGGING_MODE=''
     CFG_LOGGING_PROVIDER=''
@@ -52,6 +57,11 @@ else
     CFG_INFERENCE_ENGINE=''
     CFG_INFERENCE_DEVICE=''
     CFG_STEERING_MODE=''
+    CFG_IMU_ENABLED='false'
+    CFG_IMU_CRASH_ENABLED='false'
+    CFG_IMU_CRASH_THRESHOLD='3.0'
+    CFG_IMU_PICKUP_ENABLED='false'
+    CFG_IMU_PICKUP_THRESHOLD='0.5'
 fi
 
 # Determine inference engine and device
@@ -121,6 +131,30 @@ case "${CFG_GRAY_OVERLAY}" in
     *) GRAY_OVERLAY="enable_gray_overlay:=False" ;;
 esac
 
+# Determine IMU settings (x86 only; no-op on ARM)
+case "${CFG_IMU_ENABLED}" in
+    true|True)
+        ENABLE_IMU="enable_imu:=True"
+        case "${CFG_IMU_CRASH_ENABLED}" in
+            true|True) IMU_STOP_ON_CRASH="imu_stop_on_crash:=True" ;;
+            *) IMU_STOP_ON_CRASH="imu_stop_on_crash:=False" ;;
+        esac
+        IMU_CRASH_THRESHOLD="imu_crash_accel_threshold_g:=${CFG_IMU_CRASH_THRESHOLD:-3.0}"
+        case "${CFG_IMU_PICKUP_ENABLED}" in
+            true|True) IMU_STOP_ON_PICKUP="imu_stop_on_pickup:=True" ;;
+            *) IMU_STOP_ON_PICKUP="imu_stop_on_pickup:=False" ;;
+        esac
+        IMU_PICKUP_THRESHOLD="imu_pickup_threshold_g:=${CFG_IMU_PICKUP_THRESHOLD:-0.5}"
+        ;;
+    *)
+        ENABLE_IMU=''
+        IMU_STOP_ON_CRASH=''
+        IMU_CRASH_THRESHOLD=''
+        IMU_STOP_ON_PICKUP=''
+        IMU_PICKUP_THRESHOLD=''
+        ;;
+esac
+
 # Check if the LiDAR is connected via UART
 CP210X=$(lsusb | grep "CP210x UART Bridge")
 if [ -n "${CP210X}" ]; then
@@ -132,7 +166,7 @@ else
 fi
 
 CMD="ros2 launch deepracer_launcher deepracer_launcher.py"
-for ARG in "${INFERENCE_ENGINE}" "${INFERENCE_DEVICE}" "${BATTERY_DUMMY}" "${LOGGING_MODE}" "${LOGGING_PROVIDER}" "${CAMERA_MODE}" "${CAMERA_ORIENTATION}" "${STEERING_MODE}" "${RPLIDAR}" "${GRAY_OVERLAY}"; do
+for ARG in "${INFERENCE_ENGINE}" "${INFERENCE_DEVICE}" "${BATTERY_DUMMY}" "${LOGGING_MODE}" "${LOGGING_PROVIDER}" "${CAMERA_MODE}" "${CAMERA_ORIENTATION}" "${STEERING_MODE}" "${RPLIDAR}" "${GRAY_OVERLAY}" "${ENABLE_IMU}" "${IMU_STOP_ON_CRASH}" "${IMU_CRASH_THRESHOLD}" "${IMU_STOP_ON_PICKUP}" "${IMU_PICKUP_THRESHOLD}"; do
     [ -n "${ARG}" ] && CMD="${CMD} ${ARG}"
 done
 echo "==> ${CMD}"

--- a/src/aws-deepracer-community-imu-pkg/CMakeLists.txt
+++ b/src/aws-deepracer-community-imu-pkg/CMakeLists.txt
@@ -27,6 +27,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(sensor_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
 find_package(deepracer_interfaces_pkg REQUIRED)
 
 # Include directories
@@ -41,6 +42,7 @@ add_executable(imu_node
 ament_target_dependencies(imu_node
   rclcpp
   sensor_msgs
+  std_msgs
   deepracer_interfaces_pkg
 )
 

--- a/src/aws-deepracer-community-imu-pkg/CMakeLists.txt
+++ b/src/aws-deepracer-community-imu-pkg/CMakeLists.txt
@@ -1,0 +1,75 @@
+cmake_minimum_required(VERSION 3.8)
+project(imu_pkg)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+set(CMAKE_CXX_STANDARD 17)
+
+# Hardware platform detection (set via environment: HW_PLATFORM=DR or HW_PLATFORM=RPI)
+if(DEFINED ENV{HW_PLATFORM})
+  set(HW_PLATFORM $ENV{HW_PLATFORM})
+  message(STATUS "IMU package: using hardware platform from environment: ${HW_PLATFORM}")
+endif()
+
+if(DEFINED HW_PLATFORM)
+  if(HW_PLATFORM STREQUAL "DR")
+    add_definitions(-DHW_PLATFORM_DR)
+    message(STATUS "IMU package: building for DeepRacer (I2C bus 7)")
+  elseif(HW_PLATFORM STREQUAL "RPI")
+    add_definitions(-DHW_PLATFORM_RPI)
+    message(STATUS "IMU package: building for Raspberry Pi (I2C bus 1)")
+  endif()
+endif()
+
+# Find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(deepracer_interfaces_pkg REQUIRED)
+
+# Include directories
+include_directories(include)
+
+# Executable
+add_executable(imu_node
+  src/bmi160.cpp
+  src/imu_node.cpp
+)
+
+ament_target_dependencies(imu_node
+  rclcpp
+  sensor_msgs
+  deepracer_interfaces_pkg
+)
+
+# Install
+install(TARGETS
+  imu_node
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+install(DIRECTORY include/
+  DESTINATION include
+)
+
+install(DIRECTORY launch/
+  DESTINATION share/${PROJECT_NAME}/launch
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  find_package(ament_cmake_gtest REQUIRED)
+  set(ament_cmake_copyright_FOUND TRUE)
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+
+  ament_add_gtest(test_conversions
+    test/test_conversions.cpp
+  )
+  target_include_directories(test_conversions PRIVATE include)
+  ament_target_dependencies(test_conversions rclcpp)
+endif()
+
+ament_package()

--- a/src/aws-deepracer-community-imu-pkg/README.md
+++ b/src/aws-deepracer-community-imu-pkg/README.md
@@ -97,8 +97,8 @@ Diagonal covariances for angular velocity and linear acceleration are set to
 | `bus_id` | int | `7` (DR) / `1` (RPI) | I2C bus number |
 | `address` | int | `0x68` (104) | BMI160 I2C slave address |
 | `publish_rate` | int | `30` | Publish rate in Hz (matches camera frame rate). Also determines crash-detection polling latency (e.g. 30 Hz → up to 33 ms) |
-| `accel_range_g` | int | `4` | Accelerometer full-scale range: `2`, `4`, `8`, or `16` G |
-| `gyro_range_dps` | int | `250` | Gyroscope full-scale range: `125`, `250`, `500`, `1000`, or `2000` dps |
+| `accel_range_g` | int | `8` | Accelerometer full-scale range: `2`, `4`, `8`, or `16` G. `8` G covers ~4 G lateral at racing speeds |
+| `gyro_range_dps` | int | `1000` | Gyroscope full-scale range: `125`, `250`, `500`, `1000`, or `2000` dps. `1000` dps = 17.5 rad/s, covers tight turns at racing speed without saturation |
 | `accel_z_gravity_target` | int | `+1` | Expected sign of `accel_z` when car is flat. `+1` = upside-down mount (DeepRacer default), `-1` = normal mount |
 | `stop_on_pickup` | bool | `false` | Enable pickup detection |
 | `stop_on_crash` | bool | `false` | Enable crash detection |

--- a/src/aws-deepracer-community-imu-pkg/README.md
+++ b/src/aws-deepracer-community-imu-pkg/README.md
@@ -32,7 +32,7 @@ and **stop on pickup**.
 | Interface | Linux I2C userspace (`/dev/i2c-N`) via `ioctl` |
 | Default I2C bus | 7 (original DeepRacer), 1 (Raspberry Pi) |
 | Default I2C address | 0x68 |
-| ODR | 100 Hz (hardware), published at configurable rate (default 25 Hz) |
+| ODR | 100 Hz (hardware), published at configurable rate (default 30 Hz) |
 | Hardware filter | OSR4 (4× oversampling) — halves noise floor vs. normal mode |
 
 The BMI160 on the DeepRacer community board is mounted **upside-down** relative

--- a/src/aws-deepracer-community-imu-pkg/README.md
+++ b/src/aws-deepracer-community-imu-pkg/README.md
@@ -1,0 +1,321 @@
+# IMU Package (`imu_pkg`)
+
+**AWS DeepRacer Community** — ROS 2 package for the Bosch BMI160 6-DOF IMU.
+
+Reads the BMI160 via Linux I2C userspace (no kernel module required), publishes
+`sensor_msgs/Imu`, and provides two optional safety features: **stop on crash**
+and **stop on pickup**.
+
+---
+
+## Table of Contents
+
+1. [Hardware](#hardware)
+2. [Architecture](#architecture)
+3. [Topics and Services](#topics-and-services)
+4. [Parameters](#parameters)
+5. [Launch](#launch)
+6. [Safety Features](#safety-features)
+7. [Signal Processing](#signal-processing)
+8. [Calibration](#calibration)
+9. [Integration with deepracer\_launcher](#integration-with-deepracer_launcher)
+10. [Building and Testing](#building-and-testing)
+11. [Package Structure](#package-structure)
+
+---
+
+## Hardware
+
+| Item | Value |
+|---|---|
+| Sensor | Bosch BMI160 6-DOF IMU (accelerometer + gyroscope) |
+| Interface | Linux I2C userspace (`/dev/i2c-N`) via `ioctl` |
+| Default I2C bus | 7 (original DeepRacer), 1 (Raspberry Pi) |
+| Default I2C address | 0x68 |
+| ODR | 100 Hz (hardware), published at configurable rate (default 25 Hz) |
+| Hardware filter | OSR4 (4× oversampling) — halves noise floor vs. normal mode |
+
+The BMI160 on the DeepRacer community board is mounted **upside-down** relative
+to the vehicle frame. The driver applies axis remapping so the published data
+follows REP-103 conventions (X = forward, Y = left, Z = up) regardless of
+physical orientation.
+
+---
+
+## Architecture
+
+```
+Linux I2C (/dev/i2c-N)
+        │
+        ▼
+   BMI160 driver              (bmi160.cpp)
+   - init / configure
+   - FOC calibration
+   - readMotion6()
+   - isHighGTriggered()
+        │
+        ▼
+   conversions.hpp             (pure math, fully unit-tested)
+   - applyAxisMapping()
+   - ema()
+   - isPickupDetected()
+        │
+        ▼
+   ImuNode (imu_node.cpp)      (ROS 2 node)
+   - timerCallback @ publish_rate Hz
+   - safety checks
+   - publisher: /imu_pkg/imu_msg/data_raw
+   - client:    /ctrl_pkg/enable_state
+```
+
+---
+
+## Topics and Services
+
+### Published
+
+| Topic | Type | QoS | Notes |
+|---|---|---|---|
+| `/imu_pkg/imu_msg/data_raw` | `sensor_msgs/Imu` | Best-effort, keep-last 1 | Published only when at least one subscriber is present |
+
+The `orientation` field is always zero with `covariance[0] = -1` (unknown).
+Diagonal covariances for angular velocity and linear acceleration are set to
+`0.01` (rad/s)² and `0.01` (m/s²)² respectively as approximate defaults.
+
+### Service Clients
+
+| Service | Type | When used |
+|---|---|---|
+| `/ctrl_pkg/enable_state` | `deepracer_interfaces_pkg/EnableStateSrv` | Called with `is_active=false` on crash or pickup |
+
+---
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `bus_id` | int | `7` (DR) / `1` (RPI) | I2C bus number |
+| `address` | int | `0x68` (104) | BMI160 I2C slave address |
+| `publish_rate` | int | `30` | Publish rate in Hz (matches camera frame rate). Also determines crash-detection polling latency (e.g. 30 Hz → up to 33 ms) |
+| `accel_range_g` | int | `4` | Accelerometer full-scale range: `2`, `4`, `8`, or `16` G |
+| `gyro_range_dps` | int | `250` | Gyroscope full-scale range: `125`, `250`, `500`, `1000`, or `2000` dps |
+| `accel_z_gravity_target` | int | `+1` | Expected sign of `accel_z` when car is flat. `+1` = upside-down mount (DeepRacer default), `-1` = normal mount |
+| `stop_on_pickup` | bool | `false` | Enable pickup detection |
+| `stop_on_crash` | bool | `false` | Enable crash detection |
+| `crash_accel_threshold_g` | double | `3.0` | High-G crash threshold in G |
+| `pickup_threshold_g` | double | `0.5` | Pickup detection sensitivity in G. Increase to reduce false positives during hard cornering |
+| `filter_alpha` | double | `0.5` | EMA smoothing factor `(0, 1]`. `1.0` = no filtering; lower values give more smoothing at the cost of lag |
+
+---
+
+## Launch
+
+### Standalone
+
+```bash
+ros2 launch imu_pkg imu_pkg_launch.py
+```
+
+All parameters are exposed as launch arguments:
+
+```bash
+ros2 launch imu_pkg imu_pkg_launch.py \
+    bus_id:=7 \
+    publish_rate:=50 \
+    stop_on_crash:=true \
+    crash_accel_threshold_g:=3.0 \
+    stop_on_pickup:=true \
+    pickup_threshold_g:=0.5 \
+    filter_alpha:=0.5
+```
+
+### Monitor output
+
+```bash
+ros2 topic echo /imu_pkg/imu_msg/data_raw
+```
+
+---
+
+## Safety Features
+
+### Crash Detection (`stop_on_crash`)
+
+Uses the BMI160 hardware high-G interrupt engine — no software polling of
+acceleration values is involved.
+
+**How it works:**
+
+1. At startup, `configureHighGInterrupt()` programs the BMI160:
+   - Enables high-G monitoring on all three axes simultaneously
+   - Sets the threshold register (`INT_LOWHIGH_3`): 1 LSB = 7.81 mg, so
+     `crash_accel_threshold_g / 0.00781` → register byte
+   - Sets duration (`INT_LOWHIGH_2`) to `0x00` (1 sample = 10 ms trigger)
+   - Sets hysteresis (`INT_LOWHIGH_4`) to `0x03` (~47 mg, prevents rapid re-triggers)
+
+2. Every timer tick, `isHighGTriggered()` reads `INT_STATUS_1` (register 0x1D)
+   and checks bit 2 (`high_g_int`). The BMI160 latches this bit in hardware —
+   a brief impact won't be missed between polls. Reading the register clears it.
+
+3. When triggered, `triggerStop("crash")` calls `/ctrl_pkg/enable_state` with
+   `is_active=false` (fire-and-forget async). The car halts and **latches**
+   inactive until a human re-enables it via the web console.
+
+**Crash detection does not use the EMA filter** — it reads the raw hardware
+register, so it reacts to impacts at the sensor's full bandwidth.
+
+**Polling latency:** up to `1000 / publish_rate` ms (default ~33 ms at 30 Hz).
+Raise `publish_rate` to reduce latency (e.g. `50` → 20 ms).
+
+**Threshold guidance:**
+
+| Scenario | Typical peak G | Recommended threshold |
+|---|---|---|
+| Normal cornering/bumps | 0.5–1.5 G | — |
+| Light collision | 5–15 G | `3.0` (default) |
+| Hard wall impact at 2 m/s | ~20–40 G | `3.0` is fine |
+| Rough track surface vibration | 1–3 G | Raise to `4.0`+ if false-triggering |
+
+### Pickup Detection (`stop_on_pickup`)
+
+Uses the **EMA-filtered** `accel_z` value in software.
+
+When the car sits flat, `accel_z ≈ ±9.81 m/s²` (gravity). When picked up or
+tilted, `accel_z` shifts toward 0 (free-fall) or swings wildly.
+
+**Trigger condition:**
+
+```
+|accel_z - expected_z|  >  |expected_z| + (pickup_threshold_g × 9.81)
+```
+
+With defaults (`accel_z_gravity_target=+1`, `pickup_threshold_g=0.5`):
+- `expected_z` = +9.81 m/s²
+- Fires when `accel_z` falls below **−4.9 m/s²** or exceeds **+24.5 m/s²**
+
+This means the car must deviate more than 1.5× gravity from its resting value,
+which normal driving does not produce.
+
+**EMA lag** is intentional here — pickup is a sustained event (someone lifting
+the car) lasting hundreds of milliseconds, not a brief spike. The filter
+suppresses vibration while still catching a genuine pickup.
+
+**Tip:** If you get false positives during hard cornering, raise
+`pickup_threshold_g` to `0.8` or `1.0`.
+
+---
+
+## Signal Processing
+
+### Hardware: OSR4 Filter
+
+`ACC_CONF` and `GYR_CONF` are set to `0x08` (OSR4 oversampling mode, 100 Hz ODR).
+The BMI160 averages 4 raw samples internally before each output sample, halving
+the noise floor with no latency penalty.
+
+### Software: EMA Filter
+
+An Exponential Moving Average filter is applied to all 6 axes before publishing
+and before pickup detection:
+
+```
+filtered = alpha × current + (1 − alpha) × previous
+```
+
+| `filter_alpha` | Effect |
+|---|---|
+| `1.0` | Pass-through (no filtering) |
+| `0.5` (default) | Moderate smoothing, ~6 samples to settle |
+| `0.2` | Heavy smoothing, good for slow-changing data |
+| `0.0` | Holds previous value (fully frozen) |
+
+The crash detection check (`isHighGTriggered`) always bypasses the EMA filter
+and reads the raw hardware interrupt register.
+
+---
+
+## Calibration
+
+The node runs **Fast Offset Compensation (FOC)** at startup via the BMI160's
+built-in hardware calibration engine. FOC measures bias offsets and stores them
+in the sensor's internal offset registers — no software bias subtraction is
+needed at runtime.
+
+**Prerequisite:** The car must be **stationary and flat** when the node starts.
+Moving the car during startup will produce incorrect calibration offsets.
+
+**What FOC corrects:**
+- Accelerometer X and Y bias (target: 0 g)
+- Accelerometer Z bias (target: +1 g or −1 g, matching `accel_z_gravity_target`)
+- Gyroscope X, Y, Z bias (target: 0 dps)
+
+**Note on Z target:** The FOC hardware command operates in the raw sensor frame.
+Because the BMI160 is mounted upside-down and the driver negates the Z axis,
+the FOC Z target is the opposite of `accel_z_gravity_target`:
+- `accel_z_gravity_target=+1` (upside-down, DeepRacer default) → FOC target = −1 g in sensor frame
+- `accel_z_gravity_target=-1` (normal mount) → FOC target = +1 g in sensor frame
+
+---
+
+## Integration with deepracer\_launcher
+
+Enable the IMU node from the system-level launcher:
+
+```bash
+ros2 launch deepracer_launcher deepracer_launcher.py \
+    enable_imu:=true \
+    imu_stop_on_pickup:=true \
+    imu_stop_on_crash:=true \
+    imu_crash_accel_threshold_g:=3.0 \
+    imu_accel_z_gravity_target:=1 \
+    imu_filter_alpha:=0.5
+```
+
+The `deepracer_launcher` passes these as parameters to the same `imu_node`
+executable. `package.xml` for `deepracer_launcher` declares `<depend>imu_pkg</depend>`.
+
+---
+
+## Building and Testing
+
+```bash
+cd /workspaces/deepracer-custom-car
+
+# Build
+colcon build --packages-select imu_pkg --cmake-args -DCMAKE_BUILD_TYPE=Release
+
+# Run tests (49 unit tests + 6 linter suites)
+source install/setup.bash
+colcon test --packages-select imu_pkg --event-handlers console_direct+
+colcon test-result --packages-select imu_pkg --verbose
+```
+
+The `HW_PLATFORM` environment variable controls the default I2C bus:
+
+| `HW_PLATFORM` | Default `bus_id` |
+|---|---|
+| `DR` | 7 |
+| anything else | 1 |
+
+---
+
+## Package Structure
+
+```
+aws-deepracer-community-imu-pkg/
+├── CMakeLists.txt
+├── package.xml
+├── README.md
+├── include/
+│   └── imu_pkg/
+│       ├── bmi160.hpp          # BMI160 register map, commands, driver class declaration
+│       ├── conversions.hpp     # Pure-math helpers (axis mapping, EMA, pickup detection)
+│       └── imu_node.hpp        # ROS 2 node class declaration
+├── src/
+│   ├── bmi160.cpp              # BMI160 I2C driver implementation
+│   └── imu_node.cpp            # ROS 2 node implementation
+├── launch/
+│   └── imu_pkg_launch.py       # Standalone launch file
+└── test/
+    └── test_conversions.cpp    # GTest unit tests for conversions.hpp (49 tests)
+```

--- a/src/aws-deepracer-community-imu-pkg/README.md
+++ b/src/aws-deepracer-community-imu-pkg/README.md
@@ -52,12 +52,12 @@ Linux I2C (/dev/i2c-N)
    - init / configure
    - FOC calibration
    - readMotion6()
-   - isHighGTriggered()
         │
         ▼
    conversions.hpp             (pure math, fully unit-tested)
    - applyAxisMapping()
    - ema()
+   - isCrashDetected()
    - isPickupDetected()
         │
         ▼
@@ -141,28 +141,28 @@ ros2 topic echo /imu_pkg/imu_msg/data_raw
 
 ### Crash Detection (`stop_on_crash`)
 
-Uses the BMI160 hardware high-G interrupt engine — no software polling of
-acceleration values is involved.
+Uses a **software magnitude check** on the accel data already read each timer
+tick — no extra I2C transaction, and no impact can be missed regardless of
+duration.
 
 **How it works:**
 
-1. At startup, `configureHighGInterrupt()` programs the BMI160:
-   - Enables high-G monitoring on all three axes simultaneously
-   - Sets the threshold register (`INT_LOWHIGH_3`): 1 LSB = 7.81 mg, so
-     `crash_accel_threshold_g / 0.00781` → register byte
-   - Sets duration (`INT_LOWHIGH_2`) to `0x00` (1 sample = 10 ms trigger)
-   - Sets hysteresis (`INT_LOWHIGH_4`) to `0x03` (~47 mg, prevents rapid re-triggers)
+1. Every timer tick, after reading and filtering the 6-DOF data, `isCrashDetected()`
+   computes the Euclidean magnitude across all three axes:
 
-2. Every timer tick, `isHighGTriggered()` reads `INT_STATUS_1` (register 0x1D)
-   and checks bit 2 (`high_g_int`). The BMI160 latches this bit in hardware —
-   a brief impact won't be missed between polls. Reading the register clears it.
+   ```
+   √(accel_x² + accel_y² + accel_z²)  >  crash_accel_threshold_g × 9.81
+   ```
+
+2. The check is **orientation-agnostic** — it detects impacts on any axis without
+   special configuration.
 
 3. When triggered, `triggerStop("crash")` calls `/ctrl_pkg/enable_state` with
    `is_active=false` (fire-and-forget async). The car halts and **latches**
    inactive until a human re-enables it via the web console.
 
-**Crash detection does not use the EMA filter** — it reads the raw hardware
-register, so it reacts to impacts at the sensor's full bandwidth.
+**Crash detection uses the EMA-filtered** accel values (same as published). To
+reduce filter lag for crash detection, raise `filter_alpha` toward `1.0`.
 
 **Polling latency:** up to `1000 / publish_rate` ms (default ~33 ms at 30 Hz).
 Raise `publish_rate` to reduce latency (e.g. `50` → 20 ms).
@@ -186,15 +186,16 @@ tilted, `accel_z` shifts toward 0 (free-fall) or swings wildly.
 **Trigger condition:**
 
 ```
-|accel_z - expected_z|  >  |expected_z| + (pickup_threshold_g × 9.81)
+|accel_z - expected_z|  >  pickup_threshold_g × 9.81
 ```
 
 With defaults (`accel_z_gravity_target=+1`, `pickup_threshold_g=0.5`):
 - `expected_z` = +9.81 m/s²
-- Fires when `accel_z` falls below **−4.9 m/s²** or exceeds **+24.5 m/s²**
+- `threshold` = 0.5 × 9.81 = 4.9 m/s²
+- Fires when `accel_z` falls outside the range **[+4.9, +14.7] m/s²**
 
-This means the car must deviate more than 1.5× gravity from its resting value,
-which normal driving does not produce.
+This covers: car lifted (accel_z → 0), car placed on its side (accel_z → 0),
+and car flipped upside-down (accel_z → −9.81 m/s²).
 
 **EMA lag** is intentional here — pickup is a sustained event (someone lifting
 the car) lasting hundreds of milliseconds, not a brief spike. The filter
@@ -229,8 +230,8 @@ filtered = alpha × current + (1 − alpha) × previous
 | `0.2` | Heavy smoothing, good for slow-changing data |
 | `0.0` | Holds previous value (fully frozen) |
 
-The crash detection check (`isHighGTriggered`) always bypasses the EMA filter
-and reads the raw hardware interrupt register.
+Crash detection uses the same EMA-filtered values as the published output.
+To minimise filter lag for crash detection, raise `filter_alpha` toward `1.0`.
 
 ---
 
@@ -284,7 +285,7 @@ cd /workspaces/deepracer-custom-car
 # Build
 colcon build --packages-select imu_pkg --cmake-args -DCMAKE_BUILD_TYPE=Release
 
-# Run tests (49 unit tests + 6 linter suites)
+# Run tests (55 unit tests + linter suites)
 source install/setup.bash
 colcon test --packages-select imu_pkg --event-handlers console_direct+
 colcon test-result --packages-select imu_pkg --verbose
@@ -309,7 +310,7 @@ aws-deepracer-community-imu-pkg/
 ├── include/
 │   └── imu_pkg/
 │       ├── bmi160.hpp          # BMI160 register map, commands, driver class declaration
-│       ├── conversions.hpp     # Pure-math helpers (axis mapping, EMA, pickup detection)
+│       ├── conversions.hpp     # Pure-math helpers (axis mapping, EMA, crash/pickup detection)
 │       └── imu_node.hpp        # ROS 2 node class declaration
 ├── src/
 │   ├── bmi160.cpp              # BMI160 I2C driver implementation
@@ -317,5 +318,5 @@ aws-deepracer-community-imu-pkg/
 ├── launch/
 │   └── imu_pkg_launch.py       # Standalone launch file
 └── test/
-    └── test_conversions.cpp    # GTest unit tests for conversions.hpp (49 tests)
+    └── test_conversions.cpp    # GTest unit tests for conversions.hpp (55 tests)
 ```

--- a/src/aws-deepracer-community-imu-pkg/include/imu_pkg/bmi160.hpp
+++ b/src/aws-deepracer-community-imu-pkg/include/imu_pkg/bmi160.hpp
@@ -1,0 +1,138 @@
+///////////////////////////////////////////////////////////////////////////////////
+//   Copyright AWS DeepRacer Community. All Rights Reserved.                    //
+//                                                                               //
+//   Licensed under the Apache License, Version 2.0 (the "License").             //
+//   You may not use this file except in compliance with the License.            //
+//   You may obtain a copy of the License at                                     //
+//                                                                               //
+//       http://www.apache.org/licenses/LICENSE-2.0                              //
+//                                                                               //
+//   Unless required by applicable law or agreed to in writing, software         //
+//   distributed under the License is distributed on an "AS IS" BASIS,           //
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    //
+//   See the License for the specific language governing permissions and         //
+//   limitations under the License.                                              //
+///////////////////////////////////////////////////////////////////////////////////
+
+#ifndef IMU_PKG__BMI160_HPP_
+#define IMU_PKG__BMI160_HPP_
+
+#include <cstdint>
+#include "rclcpp/rclcpp.hpp"
+
+namespace imu_pkg
+{
+
+/// BMI160 register addresses (from datasheet BST-BMI160-DS000)
+namespace Bmi160Reg
+{
+constexpr uint8_t CHIP_ID = 0x00;  ///< Expected value: 0xD1
+constexpr uint8_t ERR_REG = 0x02;
+constexpr uint8_t DATA_GYR_X_L = 0x0C;  ///< First of 12-byte motion data block
+constexpr uint8_t INT_STATUS_1 = 0x1D;  ///< bit 2 = high_g_int (note: datasheet pg.46, reg 0x1D)
+constexpr uint8_t ACC_CONF = 0x40;  ///< ODR and bandwidth
+constexpr uint8_t ACC_RANGE = 0x41;  ///< +/-2/4/8/16 G
+constexpr uint8_t GYR_CONF = 0x42;  ///< ODR and bandwidth
+constexpr uint8_t GYR_RANGE = 0x43;  ///< +/-125..2000 dps
+constexpr uint8_t INT_EN_1 = 0x51;  ///< Interrupt enable 1 (high-G)
+constexpr uint8_t INT_MAP_1 = 0x56;  ///< Interrupt map (not used - polling only)
+constexpr uint8_t INT_LOWHIGH_2 = 0x5E;  ///< High-G duration
+constexpr uint8_t INT_LOWHIGH_3 = 0x5F;  ///< High-G threshold
+constexpr uint8_t INT_LOWHIGH_4 = 0x60;  ///< High-G hysteresis
+constexpr uint8_t FOC_CONF = 0x69;  ///< Fast Offset Compensation config
+constexpr uint8_t OFFSET_6 = 0x77;  ///< Offset enable bits
+constexpr uint8_t CMD = 0x7E;  ///< Command register
+}
+
+/// BMI160 commands
+namespace Bmi160Cmd
+{
+constexpr uint8_t ACCEL_NORMAL = 0x11;  ///< Set accelerometer to normal power mode
+constexpr uint8_t GYRO_NORMAL = 0x15;  ///< Set gyroscope to normal power mode
+constexpr uint8_t START_FOC = 0x03;  ///< Start Fast Offset Compensation
+}
+
+/// BMI160 accelerometer range register values and corresponding full-scale G values
+struct AccelRangeEntry
+{
+  int g;
+  uint8_t reg_val;
+  float lsb_per_g;  ///< LSB counts per 1 G at 16-bit full scale
+};
+
+/// BMI160 gyroscope range register values and corresponding full-scale dps values
+struct GyroRangeEntry
+{
+  int dps;
+  uint8_t reg_val;
+  float lsb_per_dps;  ///< LSB counts per 1 deg/s at 16-bit full scale
+};
+
+/// Low-level BMI160 driver communicating via Linux I2C userspace (/dev/i2c-N).
+///
+/// Usage:
+///   BMI160 imu(logger);
+///   imu.init(bus_id, address);
+///   imu.configure(4, 250);
+///   imu.calibrate(-1);
+///   int16_t gx, gy, gz, ax, ay, az;
+///   imu.readMotion6(gx, gy, gz, ax, ay, az);
+class BMI160
+{
+public:
+  explicit BMI160(rclcpp::Logger logger);
+  ~BMI160();
+
+  /// Open the I2C device and verify chip ID (0xD1).
+  /// @param bus_id  I2C bus number (e.g. 1 for /dev/i2c-1, 7 for /dev/i2c-7)
+  /// @param address Slave address (default 0x68)
+  /// @return true on success
+  bool init(int bus_id, int address);
+
+  /// Configure accelerometer and gyroscope ranges and ODR.
+  /// @param accel_range_g  Full-scale accel range in G (2, 4, 8, or 16)
+  /// @param gyro_range_dps Full-scale gyro range in dps (125, 250, 500, 1000, or 2000)
+  void configure(int accel_range_g, int gyro_range_dps);
+
+  /// Run Fast Offset Compensation to null out accel bias.
+  /// Assumes the car is stationary on flat ground.
+  /// @param z_gravity_target +1 for upside-down mounting, -1 for normal mounting
+  void calibrate(int z_gravity_target);
+
+  /// Enable the BMI160 hardware high-G interrupt detection circuitry.
+  /// The node polls INT_STATUS_1 rather than reading the INT1 pin.
+  /// @param threshold_g  Acceleration magnitude that triggers the interrupt (in G)
+  void configureHighGInterrupt(float threshold_g);
+
+  /// Burst-read all 6-DOF raw data from the BMI160.
+  /// Register layout 0x0C–0x17: GX_L GX_H GY_L GY_H GZ_L GZ_H AX_L AX_H AY_L AY_H AZ_L AZ_H
+  /// @return true on success
+  bool readMotion6(
+    int16_t & gx, int16_t & gy, int16_t & gz,
+    int16_t & ax, int16_t & ay, int16_t & az);
+
+  /// Check whether the hardware high-G interrupt is currently asserted.
+  /// Reads INT_STATUS_1 (0x1D); bit 2 = high_g_int.
+  bool isHighGTriggered();
+
+  /// Physical scale factors (set by configure())
+  float accel_scale() const {return accel_scale_;}     ///< m/s² per LSB
+  float gyro_scale() const {return gyro_scale_;}       ///< rad/s per LSB
+
+private:
+  // I2C helpers
+  int  openDevice(int bus_id, int address);
+  bool writeRegister(int fd, uint8_t reg, uint8_t val);
+  int  readRegister(int fd, uint8_t reg);
+  bool readRegisters(int fd, uint8_t reg, int len, uint8_t * buf);
+
+  rclcpp::Logger logger_;
+  int bus_id_{1};
+  int address_{0x68};
+  float accel_scale_{0.0f};
+  float gyro_scale_{0.0f};
+};
+
+}  // namespace imu_pkg
+
+#endif  // IMU_PKG__BMI160_HPP_

--- a/src/aws-deepracer-community-imu-pkg/include/imu_pkg/conversions.hpp
+++ b/src/aws-deepracer-community-imu-pkg/include/imu_pkg/conversions.hpp
@@ -124,8 +124,8 @@ inline MotionData applyAxisMapping(
 /// Return true when the IMU Z-axis reading suggests the car has been picked up.
 ///
 /// A pickup is detected when the measured accel_z deviates from the expected
-/// gravity value by more than (|expected_z| + threshold):
-///   |accel_z - expected_z|  >  |expected_z| + threshold_ms2
+/// gravity value by more than threshold:
+///   |accel_z - expected_z|  >  threshold_ms2
 ///
 /// @param accel_z_ms2        Measured Z acceleration in m/s²
 /// @param z_gravity_target   +1 for upside-down mount, -1 for normal mount
@@ -137,7 +137,7 @@ inline bool isPickupDetected(
 {
   const double expected_z = z_gravity_target * GRAVITY_MS2;
   const double threshold_ms2 = pickup_threshold_g * GRAVITY_MS2;
-  return std::abs(accel_z_ms2 - expected_z) > std::abs(expected_z) + threshold_ms2;
+  return std::abs(accel_z_ms2 - expected_z) > threshold_ms2;
 }
 
 // -------------------------------------------------------------------------

--- a/src/aws-deepracer-community-imu-pkg/include/imu_pkg/conversions.hpp
+++ b/src/aws-deepracer-community-imu-pkg/include/imu_pkg/conversions.hpp
@@ -108,7 +108,7 @@ inline MotionData applyAxisMapping(
 {
   MotionData out;
   out.gyro_x = static_cast<float>(raw_gy) * gyro_scale;
-  out.gyro_y = static_cast<float>(raw_gx) * gyro_scale;
+  out.gyro_y = -static_cast<float>(raw_gx) * gyro_scale;
   out.gyro_z = -static_cast<float>(raw_gz) * gyro_scale;
 
   out.accel_x = static_cast<float>(raw_ay) * accel_scale;

--- a/src/aws-deepracer-community-imu-pkg/include/imu_pkg/conversions.hpp
+++ b/src/aws-deepracer-community-imu-pkg/include/imu_pkg/conversions.hpp
@@ -50,7 +50,10 @@ static constexpr float  HIGH_G_THRESH_LSB_PER_G = 1.0f / 0.00781f;
 ///                       Falls back to ±4G for unrecognised values.
 inline float computeAccelScale(int accel_range_g)
 {
-  const float lsb_per_g = FULL_SCALE_16BIT / static_cast<float>(accel_range_g);
+  const bool is_valid = (accel_range_g == 2 || accel_range_g == 4 ||
+                         accel_range_g == 8 || accel_range_g == 16);
+  const int range = is_valid ? accel_range_g : 4;
+  const float lsb_per_g = FULL_SCALE_16BIT / static_cast<float>(range);
   return static_cast<float>(GRAVITY_MS2) / lsb_per_g;
 }
 
@@ -59,7 +62,11 @@ inline float computeAccelScale(int accel_range_g)
 ///                        Falls back to ±250 dps for unrecognised values.
 inline float computeGyroScale(int gyro_range_dps)
 {
-  const float lsb_per_dps = FULL_SCALE_16BIT / static_cast<float>(gyro_range_dps);
+  const bool is_valid = (gyro_range_dps == 125 || gyro_range_dps == 250 ||
+                         gyro_range_dps == 500 || gyro_range_dps == 1000 ||
+                         gyro_range_dps == 2000);
+  const int range = is_valid ? gyro_range_dps : 250;
+  const float lsb_per_dps = FULL_SCALE_16BIT / static_cast<float>(range);
   return (static_cast<float>(M_PI) / 180.0f) / lsb_per_dps;
 }
 

--- a/src/aws-deepracer-community-imu-pkg/include/imu_pkg/conversions.hpp
+++ b/src/aws-deepracer-community-imu-pkg/include/imu_pkg/conversions.hpp
@@ -118,6 +118,30 @@ inline MotionData applyAxisMapping(
 }
 
 // -------------------------------------------------------------------------
+// Crash detection
+// -------------------------------------------------------------------------
+
+/// Return true when the total acceleration magnitude indicates a crash.
+///
+/// Uses the Euclidean magnitude of all three axes, so it is orientation-agnostic.
+///   sqrt(x² + y² + z²) > threshold_ms2
+///
+/// @param accel_x/y/z_ms2    Measured accelerations in m/s² (vehicle frame)
+/// @param crash_threshold_g  Threshold in G (converted internally to m/s²)
+inline bool isCrashDetected(
+  double accel_x_ms2,
+  double accel_y_ms2,
+  double accel_z_ms2,
+  double crash_threshold_g)
+{
+  const double magnitude = std::sqrt(
+    accel_x_ms2 * accel_x_ms2 +
+    accel_y_ms2 * accel_y_ms2 +
+    accel_z_ms2 * accel_z_ms2);
+  return magnitude > crash_threshold_g * GRAVITY_MS2;
+}
+
+// -------------------------------------------------------------------------
 // Pickup detection
 // -------------------------------------------------------------------------
 

--- a/src/aws-deepracer-community-imu-pkg/include/imu_pkg/conversions.hpp
+++ b/src/aws-deepracer-community-imu-pkg/include/imu_pkg/conversions.hpp
@@ -140,6 +140,23 @@ inline bool isPickupDetected(
   return std::abs(accel_z_ms2 - expected_z) > std::abs(expected_z) + threshold_ms2;
 }
 
+// -------------------------------------------------------------------------
+// Software exponential moving average (EMA) filter
+// -------------------------------------------------------------------------
+
+/// Apply one step of an exponential moving average filter.
+///
+/// filtered = alpha * current + (1 - alpha) * previous
+///
+/// @param current   New raw sample.
+/// @param previous  Previous filtered value.
+/// @param alpha     Smoothing factor in (0, 1]. 1.0 = no filtering (pass-through);
+///                  lower values give heavier smoothing but more lag.
+inline float ema(float current, float previous, float alpha)
+{
+  return alpha * current + (1.0f - alpha) * previous;
+}
+
 }  // namespace conversions
 }  // namespace imu_pkg
 

--- a/src/aws-deepracer-community-imu-pkg/include/imu_pkg/conversions.hpp
+++ b/src/aws-deepracer-community-imu-pkg/include/imu_pkg/conversions.hpp
@@ -1,0 +1,146 @@
+///////////////////////////////////////////////////////////////////////////////////
+//   Copyright AWS DeepRacer Community. All Rights Reserved.                    //
+//                                                                               //
+//   Licensed under the Apache License, Version 2.0 (the "License").             //
+//   You may not use this file except in compliance with the License.            //
+//   You may obtain a copy of the License at                                     //
+//                                                                               //
+//       http://www.apache.org/licenses/LICENSE-2.0                              //
+//                                                                               //
+//   Unless required by applicable law or agreed to in writing, software         //
+//   distributed under the License is distributed on an "AS IS" BASIS,           //
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    //
+//   See the License for the specific language governing permissions and         //
+//   limitations under the License.                                              //
+///////////////////////////////////////////////////////////////////////////////////
+
+#ifndef IMU_PKG__CONVERSIONS_HPP_
+#define IMU_PKG__CONVERSIONS_HPP_
+
+/// @file conversions.hpp
+/// Pure-math helpers for BMI160 data conversion.
+/// No ROS2 or I2C dependencies — fully unit-testable in isolation.
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+
+namespace imu_pkg
+{
+namespace conversions
+{
+
+// -------------------------------------------------------------------------
+// Physical constants
+// -------------------------------------------------------------------------
+
+/// Standard gravity (m/s²)
+static constexpr double GRAVITY_MS2 = 9.80665;
+/// Half the 16-bit signed range (2^15)
+static constexpr float  FULL_SCALE_16BIT = 32768.0f;
+/// BMI160 high-G threshold: 1 register LSB = 7.81 mg (datasheet table 22)
+static constexpr float  HIGH_G_THRESH_LSB_PER_G = 1.0f / 0.00781f;
+
+// -------------------------------------------------------------------------
+// Scale factor computation
+// -------------------------------------------------------------------------
+
+/// Compute the accelerometer scale factor in m/s² per raw LSB.
+/// @param accel_range_g  Full-scale range in G (2, 4, 8, or 16).
+///                       Falls back to ±4G for unrecognised values.
+inline float computeAccelScale(int accel_range_g)
+{
+  const float lsb_per_g = FULL_SCALE_16BIT / static_cast<float>(accel_range_g);
+  return static_cast<float>(GRAVITY_MS2) / lsb_per_g;
+}
+
+/// Compute the gyroscope scale factor in rad/s per raw LSB.
+/// @param gyro_range_dps  Full-scale range in dps (125, 250, 500, 1000, or 2000).
+///                        Falls back to ±250 dps for unrecognised values.
+inline float computeGyroScale(int gyro_range_dps)
+{
+  const float lsb_per_dps = FULL_SCALE_16BIT / static_cast<float>(gyro_range_dps);
+  return (static_cast<float>(M_PI) / 180.0f) / lsb_per_dps;
+}
+
+// -------------------------------------------------------------------------
+// Register encoding
+// -------------------------------------------------------------------------
+
+/// Encode a crash threshold in G as the BMI160 INT_LOWHIGH_3 register byte.
+/// 1 LSB ≈ 7.81 mg; clamped to [0, 255].
+inline uint8_t encodeHighGThreshold(float threshold_g)
+{
+  const float raw = threshold_g * HIGH_G_THRESH_LSB_PER_G;
+  return static_cast<uint8_t>(std::min(255.0f, std::max(0.0f, raw)));
+}
+
+// -------------------------------------------------------------------------
+// Axis mapping & scaling
+// -------------------------------------------------------------------------
+
+/// Result of applying the BMI160→vehicle-frame axis mapping.
+struct MotionData
+{
+  float gyro_x;   ///< rad/s, vehicle frame
+  float gyro_y;   ///< rad/s, vehicle frame
+  float gyro_z;   ///< rad/s, vehicle frame
+  float accel_x;  ///< m/s², vehicle frame
+  float accel_y;  ///< m/s², vehicle frame
+  float accel_z;  ///< m/s², vehicle frame
+};
+
+/// Convert raw BMI160 sensor readings to vehicle-frame physical units.
+///
+/// Axis mapping (mirrors reference Python node):
+///   published X  ←  sensor Y
+///   published Y  ←  sensor X
+///   published Z  ←  -(sensor Z)   (Z inverted regardless of mount orientation;
+///                                   calibration already corrects the bias offset)
+///
+/// @param raw_gx..raw_az  Raw int16 values from the BMI160 data registers.
+/// @param accel_scale     m/s² per LSB (from computeAccelScale)
+/// @param gyro_scale      rad/s per LSB (from computeGyroScale)
+inline MotionData applyAxisMapping(
+  int16_t raw_gx, int16_t raw_gy, int16_t raw_gz,
+  int16_t raw_ax, int16_t raw_ay, int16_t raw_az,
+  float accel_scale, float gyro_scale)
+{
+  MotionData out;
+  out.gyro_x = static_cast<float>(raw_gy) * gyro_scale;
+  out.gyro_y = static_cast<float>(raw_gx) * gyro_scale;
+  out.gyro_z = -static_cast<float>(raw_gz) * gyro_scale;
+
+  out.accel_x = static_cast<float>(raw_ay) * accel_scale;
+  out.accel_y = static_cast<float>(raw_ax) * accel_scale;
+  out.accel_z = -static_cast<float>(raw_az) * accel_scale;
+  return out;
+}
+
+// -------------------------------------------------------------------------
+// Pickup detection
+// -------------------------------------------------------------------------
+
+/// Return true when the IMU Z-axis reading suggests the car has been picked up.
+///
+/// A pickup is detected when the measured accel_z deviates from the expected
+/// gravity value by more than (|expected_z| + threshold):
+///   |accel_z - expected_z|  >  |expected_z| + threshold_ms2
+///
+/// @param accel_z_ms2        Measured Z acceleration in m/s²
+/// @param z_gravity_target   +1 for upside-down mount, -1 for normal mount
+/// @param pickup_threshold_g Threshold in G (converted internally to m/s²)
+inline bool isPickupDetected(
+  double accel_z_ms2,
+  int z_gravity_target,
+  double pickup_threshold_g)
+{
+  const double expected_z = z_gravity_target * GRAVITY_MS2;
+  const double threshold_ms2 = pickup_threshold_g * GRAVITY_MS2;
+  return std::abs(accel_z_ms2 - expected_z) > std::abs(expected_z) + threshold_ms2;
+}
+
+}  // namespace conversions
+}  // namespace imu_pkg
+
+#endif  // IMU_PKG__CONVERSIONS_HPP_

--- a/src/aws-deepracer-community-imu-pkg/include/imu_pkg/imu_node.hpp
+++ b/src/aws-deepracer-community-imu-pkg/include/imu_pkg/imu_node.hpp
@@ -86,6 +86,9 @@ private:
   float prev_accel_y_{0.0f};
   float prev_accel_z_{0.0f};
   bool  filter_initialized_{false};
+
+  // ---------- Safety stop throttle ----------
+  rclcpp::Time last_stop_time_{0, 0, RCL_ROS_TIME};
 };
 
 }  // namespace imu_pkg

--- a/src/aws-deepracer-community-imu-pkg/include/imu_pkg/imu_node.hpp
+++ b/src/aws-deepracer-community-imu-pkg/include/imu_pkg/imu_node.hpp
@@ -76,6 +76,16 @@ private:
   bool   stop_on_crash_;
   double crash_accel_threshold_g_;
   double pickup_threshold_g_;
+  double filter_alpha_{1.0};  ///< EMA smoothing factor; 1.0 = off
+
+  // ---------- EMA filter state ----------
+  float prev_gyro_x_{0.0f};
+  float prev_gyro_y_{0.0f};
+  float prev_gyro_z_{0.0f};
+  float prev_accel_x_{0.0f};
+  float prev_accel_y_{0.0f};
+  float prev_accel_z_{0.0f};
+  bool  filter_initialized_{false};
 };
 
 }  // namespace imu_pkg

--- a/src/aws-deepracer-community-imu-pkg/include/imu_pkg/imu_node.hpp
+++ b/src/aws-deepracer-community-imu-pkg/include/imu_pkg/imu_node.hpp
@@ -1,0 +1,83 @@
+///////////////////////////////////////////////////////////////////////////////////
+//   Copyright AWS DeepRacer Community. All Rights Reserved.                    //
+//                                                                               //
+//   Licensed under the Apache License, Version 2.0 (the "License").             //
+//   You may not use this file except in compliance with the License.            //
+//   You may obtain a copy of the License at                                     //
+//                                                                               //
+//       http://www.apache.org/licenses/LICENSE-2.0                              //
+//                                                                               //
+//   Unless required by applicable law or agreed to in writing, software         //
+//   distributed under the License is distributed on an "AS IS" BASIS,           //
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    //
+//   See the License for the specific language governing permissions and         //
+//   limitations under the License.                                              //
+///////////////////////////////////////////////////////////////////////////////////
+
+#ifndef IMU_PKG__IMU_NODE_HPP_
+#define IMU_PKG__IMU_NODE_HPP_
+
+#include <memory>
+#include <string>
+
+#include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/imu.hpp"
+#include "deepracer_interfaces_pkg/srv/enable_state_srv.hpp"
+#include "imu_pkg/bmi160.hpp"
+
+namespace imu_pkg
+{
+
+/// IMU node for AWS DeepRacer / DeepRacer Community
+///
+/// Reads the Bosch BMI160 6-DOF IMU via Linux I2C and:
+///   - Publishes sensor_msgs/Imu on /imu_pkg/imu_msg/data_raw
+///     (only when at least one subscriber is present)
+///   - Optionally calls the ctrl_pkg vehicle_state service with
+///     is_active=false when a crash (high-G) or pickup is detected.
+class ImuNode : public rclcpp::Node
+{
+public:
+  explicit ImuNode();
+  ~ImuNode() = default;
+
+private:
+  // Callbacks
+  void timerCallback();
+  void heartbeatCallback();
+
+  // Safety actions
+  void triggerStop(const std::string & reason);
+
+  // Sensor initialisation (called once after construction)
+  bool initSensor();
+
+  // ---------- Publishers / Clients ----------
+  rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr imu_publisher_;
+  rclcpp::Client<deepracer_interfaces_pkg::srv::EnableStateSrv>::SharedPtr
+    vehicle_state_client_;
+
+  // ---------- Timers ----------
+  rclcpp::TimerBase::SharedPtr publish_timer_;
+  rclcpp::TimerBase::SharedPtr heartbeat_timer_;
+  int heartbeat_count_{0};
+
+  // ---------- IMU driver ----------
+  std::unique_ptr<BMI160> imu_;
+
+  // ---------- Parameters (cached after construction) ----------
+  int    bus_id_;
+  int    address_;
+  int    publish_rate_;
+  int    accel_range_g_;
+  int    gyro_range_dps_;
+  int    accel_z_gravity_target_;
+  bool   stop_on_pickup_;
+  bool   stop_on_crash_;
+  double crash_accel_threshold_g_;
+  double pickup_threshold_g_;
+};
+
+}  // namespace imu_pkg
+
+#endif  // IMU_PKG__IMU_NODE_HPP_

--- a/src/aws-deepracer-community-imu-pkg/include/imu_pkg/imu_node.hpp
+++ b/src/aws-deepracer-community-imu-pkg/include/imu_pkg/imu_node.hpp
@@ -22,6 +22,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/imu.hpp"
+#include "std_msgs/msg/string.hpp"
 #include "deepracer_interfaces_pkg/srv/enable_state_srv.hpp"
 #include "imu_pkg/bmi160.hpp"
 
@@ -54,6 +55,7 @@ private:
 
   // ---------- Publishers / Clients ----------
   rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr imu_publisher_;
+  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr safety_event_publisher_;
   rclcpp::Client<deepracer_interfaces_pkg::srv::EnableStateSrv>::SharedPtr
     vehicle_state_client_;
 

--- a/src/aws-deepracer-community-imu-pkg/launch/imu_pkg_launch.py
+++ b/src/aws-deepracer-community-imu-pkg/launch/imu_pkg_launch.py
@@ -1,0 +1,85 @@
+################################################################################
+#   Copyright AWS DeepRacer Community. All Rights Reserved.                   #
+#                                                                              #
+#   Licensed under the Apache License, Version 2.0 (the 'License').            #
+#   You may not use this file except in compliance with the License.           #
+#   You may obtain a copy of the License at                                    #
+#                                                                              #
+#       http://www.apache.org/licenses/LICENSE-2.0                             #
+#                                                                              #
+#   Unless required by applicable law or agreed to in writing, software        #
+#   distributed under the License is distributed on an 'AS IS' BASIS,          #
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   #
+#   See the License for the specific language governing permissions and        #
+#   limitations under the License.                                             #
+################################################################################
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    return LaunchDescription([
+        DeclareLaunchArgument(
+            name='bus_id',
+            default_value='1',
+            description='I2C bus number (1 for Raspberry Pi, 7 for original DeepRacer)'),
+        DeclareLaunchArgument(
+            name='address',
+            default_value='104',   # 0x68 in decimal
+            description='BMI160 I2C slave address (default: 0x68 = 104)'),
+        DeclareLaunchArgument(
+            name='publish_rate',
+            default_value='25',
+            description='IMU publish rate in Hz'),
+        DeclareLaunchArgument(
+            name='accel_range_g',
+            default_value='4',
+            description='Accelerometer full-scale range in G (2, 4, 8, or 16)'),
+        DeclareLaunchArgument(
+            name='gyro_range_dps',
+            default_value='250',
+            description='Gyroscope full-scale range in dps (125, 250, 500, 1000, or 2000)'),
+        DeclareLaunchArgument(
+            name='accel_z_gravity_target',
+            default_value='-1',
+            description='Expected Z-axis gravity direction: -1 for normal mounting, '
+                        '+1 for upside-down mounting'),
+        DeclareLaunchArgument(
+            name='stop_on_pickup',
+            default_value='False',
+            description='Stop the vehicle when the IMU detects it has been picked up'),
+        DeclareLaunchArgument(
+            name='stop_on_crash',
+            default_value='False',
+            description='Stop the vehicle when the IMU detects a high-G crash event'),
+        DeclareLaunchArgument(
+            name='crash_accel_threshold_g',
+            default_value='3.0',
+            description='Acceleration magnitude (in G) that triggers the crash stop'),
+        DeclareLaunchArgument(
+            name='pickup_threshold_g',
+            default_value='0.5',
+            description='How much the Z-axis acceleration must deviate from the expected '
+                        'gravity value (in G) to be considered a pickup event'),
+        Node(
+            package='imu_pkg',
+            namespace='imu_pkg',
+            executable='imu_node',
+            name='imu_node',
+            parameters=[{
+                'bus_id':                 LaunchConfiguration('bus_id'),
+                'address':                LaunchConfiguration('address'),
+                'publish_rate':           LaunchConfiguration('publish_rate'),
+                'accel_range_g':          LaunchConfiguration('accel_range_g'),
+                'gyro_range_dps':         LaunchConfiguration('gyro_range_dps'),
+                'accel_z_gravity_target': LaunchConfiguration('accel_z_gravity_target'),
+                'stop_on_pickup':         LaunchConfiguration('stop_on_pickup'),
+                'stop_on_crash':          LaunchConfiguration('stop_on_crash'),
+                'crash_accel_threshold_g': LaunchConfiguration('crash_accel_threshold_g'),
+                'pickup_threshold_g':     LaunchConfiguration('pickup_threshold_g'),
+            }]
+        ),
+    ])

--- a/src/aws-deepracer-community-imu-pkg/launch/imu_pkg_launch.py
+++ b/src/aws-deepracer-community-imu-pkg/launch/imu_pkg_launch.py
@@ -64,6 +64,10 @@ def generate_launch_description():
             default_value='0.5',
             description='How much the Z-axis acceleration must deviate from the expected '
                         'gravity value (in G) to be considered a pickup event'),
+        DeclareLaunchArgument(
+            name='filter_alpha',
+            default_value='0.5',
+            description='EMA smoothing factor (0, 1]: 1.0 = no filtering, lower = more smoothing'),
         Node(
             package='imu_pkg',
             namespace='imu_pkg',
@@ -80,6 +84,7 @@ def generate_launch_description():
                 'stop_on_crash':          LaunchConfiguration('stop_on_crash'),
                 'crash_accel_threshold_g': LaunchConfiguration('crash_accel_threshold_g'),
                 'pickup_threshold_g':     LaunchConfiguration('pickup_threshold_g'),
+                'filter_alpha':           LaunchConfiguration('filter_alpha'),
             }]
         ),
     ])

--- a/src/aws-deepracer-community-imu-pkg/launch/imu_pkg_launch.py
+++ b/src/aws-deepracer-community-imu-pkg/launch/imu_pkg_launch.py
@@ -37,11 +37,13 @@ def generate_launch_description():
         DeclareLaunchArgument(
             name='accel_range_g',
             default_value='8',
-            description='Accelerometer full-scale range in G (2, 4, 8, or 16)'),  # 8G covers ~4G lateral at racing speeds
+            # 8G covers ~4G lateral at racing speeds
+            description='Accelerometer full-scale range in G (2, 4, 8, or 16)'),
         DeclareLaunchArgument(
             name='gyro_range_dps',
             default_value='1000',
-            description='Gyroscope full-scale range in dps (125, 250, 500, 1000, or 2000)'),  # 1000dps = 17.5 rad/s, covers tight turns at racing speed
+            # 1000dps = 17.5 rad/s, covers tight turns at racing speed
+            description='Gyroscope full-scale range in dps (125, 250, 500, 1000, or 2000)'),
         DeclareLaunchArgument(
             name='accel_z_gravity_target',
             default_value='1',

--- a/src/aws-deepracer-community-imu-pkg/launch/imu_pkg_launch.py
+++ b/src/aws-deepracer-community-imu-pkg/launch/imu_pkg_launch.py
@@ -36,12 +36,12 @@ def generate_launch_description():
             description='IMU publish rate in Hz'),  # matches camera frame rate
         DeclareLaunchArgument(
             name='accel_range_g',
-            default_value='4',
-            description='Accelerometer full-scale range in G (2, 4, 8, or 16)'),
+            default_value='8',
+            description='Accelerometer full-scale range in G (2, 4, 8, or 16)'),  # 8G covers ~4G lateral at racing speeds
         DeclareLaunchArgument(
             name='gyro_range_dps',
-            default_value='250',
-            description='Gyroscope full-scale range in dps (125, 250, 500, 1000, or 2000)'),
+            default_value='1000',
+            description='Gyroscope full-scale range in dps (125, 250, 500, 1000, or 2000)'),  # 1000dps = 17.5 rad/s, covers tight turns at racing speed
         DeclareLaunchArgument(
             name='accel_z_gravity_target',
             default_value='1',

--- a/src/aws-deepracer-community-imu-pkg/launch/imu_pkg_launch.py
+++ b/src/aws-deepracer-community-imu-pkg/launch/imu_pkg_launch.py
@@ -32,8 +32,8 @@ def generate_launch_description():
             description='BMI160 I2C slave address (default: 0x68 = 104)'),
         DeclareLaunchArgument(
             name='publish_rate',
-            default_value='25',
-            description='IMU publish rate in Hz'),
+            default_value='30',
+            description='IMU publish rate in Hz'),  # matches camera frame rate
         DeclareLaunchArgument(
             name='accel_range_g',
             default_value='4',

--- a/src/aws-deepracer-community-imu-pkg/launch/imu_pkg_launch.py
+++ b/src/aws-deepracer-community-imu-pkg/launch/imu_pkg_launch.py
@@ -24,8 +24,8 @@ def generate_launch_description():
     return LaunchDescription([
         DeclareLaunchArgument(
             name='bus_id',
-            default_value='1',
-            description='I2C bus number (1 for Raspberry Pi, 7 for original DeepRacer)'),
+            default_value='7',
+            description='I2C bus number (7 for original DeepRacer, 1 for Raspberry Pi)'),
         DeclareLaunchArgument(
             name='address',
             default_value='104',   # 0x68 in decimal

--- a/src/aws-deepracer-community-imu-pkg/launch/imu_pkg_launch.py
+++ b/src/aws-deepracer-community-imu-pkg/launch/imu_pkg_launch.py
@@ -44,9 +44,9 @@ def generate_launch_description():
             description='Gyroscope full-scale range in dps (125, 250, 500, 1000, or 2000)'),
         DeclareLaunchArgument(
             name='accel_z_gravity_target',
-            default_value='-1',
-            description='Expected Z-axis gravity direction: -1 for normal mounting, '
-                        '+1 for upside-down mounting'),
+            default_value='1',
+            description='Expected published accel_z direction when flat: +1 for upside-down '
+                        'mounting (DeepRacer default), -1 for normal mounting'),
         DeclareLaunchArgument(
             name='stop_on_pickup',
             default_value='False',

--- a/src/aws-deepracer-community-imu-pkg/launch/imu_pkg_launch.py
+++ b/src/aws-deepracer-community-imu-pkg/launch/imu_pkg_launch.py
@@ -24,8 +24,9 @@ def generate_launch_description():
     return LaunchDescription([
         DeclareLaunchArgument(
             name='bus_id',
-            default_value='7',
-            description='I2C bus number (7 for original DeepRacer, 1 for Raspberry Pi)'),
+            default_value='1',
+            description='I2C bus number for the BMI160 (1 on both original DeepRacer and Raspberry Pi)'),
+        # Note: override with bus_id:=<N> if your hardware uses a different bus.
         DeclareLaunchArgument(
             name='address',
             default_value='104',   # 0x68 in decimal

--- a/src/aws-deepracer-community-imu-pkg/package.xml
+++ b/src/aws-deepracer-community-imu-pkg/package.xml
@@ -16,6 +16,7 @@
 
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
   <depend>deepracer_interfaces_pkg</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/src/aws-deepracer-community-imu-pkg/package.xml
+++ b/src/aws-deepracer-community-imu-pkg/package.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>imu_pkg</name>
+  <version>1.0.0</version>
+  <description>
+    AWS DeepRacer Community IMU Package — reads the Bosch BMI160 6-DOF
+    inertial measurement unit via Linux I2C userspace, publishes
+    sensor_msgs/Imu, and optionally stops the vehicle on crash (high-G)
+    or pickup detection.
+  </description>
+  <maintainer email="nomail@deepracing.io">AWS DeepRacer Community</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>sensor_msgs</depend>
+  <depend>deepracer_interfaces_pkg</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/aws-deepracer-community-imu-pkg/src/bmi160.cpp
+++ b/src/aws-deepracer-community-imu-pkg/src/bmi160.cpp
@@ -1,0 +1,301 @@
+///////////////////////////////////////////////////////////////////////////////////
+//   Copyright AWS DeepRacer Community. All Rights Reserved.                    //
+//                                                                               //
+//   Licensed under the Apache License, Version 2.0 (the "License").             //
+//   You may not use this file except in compliance with the License.            //
+//   You may obtain a copy of the License at                                     //
+//                                                                               //
+//       http://www.apache.org/licenses/LICENSE-2.0                              //
+//                                                                               //
+//   Unless required by applicable law or agreed to in writing, software         //
+//   distributed under the License is distributed on an "AS IS" BASIS,           //
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    //
+//   See the License for the specific language governing permissions and         //
+//   limitations under the License.                                              //
+///////////////////////////////////////////////////////////////////////////////////
+
+#include "imu_pkg/bmi160.hpp"
+#include "imu_pkg/conversions.hpp"
+
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+#include <linux/i2c.h>
+#include <linux/i2c-dev.h>
+
+#include <cerrno>
+#include <cmath>
+#include <cstring>
+#include <stdexcept>
+#include <thread>
+#include <chrono>
+
+namespace imu_pkg
+{
+
+// ----- Physical constants -----------------------------------------------
+
+static constexpr float GRAVITY_MS2 = 9.80665f;
+static constexpr float FULL_SCALE_16BIT = 32768.0f;  // 2^15
+
+// Accelerometer: register value → full-scale G mapping (datasheet table 16)
+static const AccelRangeEntry ACCEL_RANGES[] = {
+  {2, 0x03, FULL_SCALE_16BIT / 2.0f},
+  {4, 0x05, FULL_SCALE_16BIT / 4.0f},
+  {8, 0x08, FULL_SCALE_16BIT / 8.0f},
+  {16, 0x0C, FULL_SCALE_16BIT / 16.0f},
+};
+
+// Gyroscope: register value → full-scale dps mapping (datasheet table 17)
+static const GyroRangeEntry GYRO_RANGES[] = {
+  {125, 0x04, FULL_SCALE_16BIT / 125.0f},
+  {250, 0x03, FULL_SCALE_16BIT / 250.0f},
+  {500, 0x02, FULL_SCALE_16BIT / 500.0f},
+  {1000, 0x01, FULL_SCALE_16BIT / 1000.0f},
+  {2000, 0x00, FULL_SCALE_16BIT / 2000.0f},
+};
+
+// High-G threshold register: 1 LSB = 7.81 mg for all accel ranges (datasheet table 22)
+static constexpr float HIGH_G_THRESH_LSB_PER_G = 1.0f / 0.00781f;
+
+// ----- Constructor / Destructor -----------------------------------------
+
+BMI160::BMI160(rclcpp::Logger logger)
+: logger_(logger) {}
+
+BMI160::~BMI160() {}
+
+// ----- I2C helpers -------------------------------------------------------
+
+int BMI160::openDevice(int bus_id, int address)
+{
+  char path[32];
+  snprintf(path, sizeof(path), "/dev/i2c-%d", bus_id);
+
+  int fd = open(path, O_RDWR);
+  if (fd < 0) {
+    RCLCPP_ERROR(logger_, "BMI160: cannot open %s: %s", path, strerror(errno));
+    return -1;
+  }
+  if (ioctl(fd, I2C_SLAVE, address) < 0) {
+    RCLCPP_ERROR(
+      logger_, "BMI160: cannot set I2C slave 0x%02X on %s: %s",
+      address, path, strerror(errno));
+    close(fd);
+    return -1;
+  }
+  return fd;
+}
+
+bool BMI160::writeRegister(int fd, uint8_t reg, uint8_t val)
+{
+  uint8_t buf[2] = {reg, val};
+  if (write(fd, buf, 2) != 2) {
+    RCLCPP_ERROR(
+      logger_, "BMI160: write failed reg=0x%02X val=0x%02X: %s",
+      reg, val, strerror(errno));
+    return false;
+  }
+  return true;
+}
+
+int BMI160::readRegister(int fd, uint8_t reg)
+{
+  uint8_t buf = reg;
+  if (write(fd, &buf, 1) != 1) {
+    RCLCPP_ERROR(logger_, "BMI160: write (set reg 0x%02X) failed: %s", reg, strerror(errno));
+    return -1;
+  }
+  uint8_t val = 0;
+  if (read(fd, &val, 1) != 1) {
+    RCLCPP_ERROR(logger_, "BMI160: read failed reg=0x%02X: %s", reg, strerror(errno));
+    return -1;
+  }
+  return static_cast<int>(val);
+}
+
+bool BMI160::readRegisters(int fd, uint8_t reg, int len, uint8_t * buf)
+{
+  uint8_t r = reg;
+  if (write(fd, &r, 1) != 1) {
+    RCLCPP_ERROR(logger_, "BMI160: write (set reg 0x%02X) failed: %s", reg, strerror(errno));
+    return false;
+  }
+  if (read(fd, buf, len) != len) {
+    RCLCPP_ERROR(logger_, "BMI160: burst-read %d bytes from reg=0x%02X failed: %s",
+      len, reg, strerror(errno));
+    return false;
+  }
+  return true;
+}
+
+// ----- Public API --------------------------------------------------------
+
+bool BMI160::init(int bus_id, int address)
+{
+  bus_id_ = bus_id;
+  address_ = address;
+
+  int fd = openDevice(bus_id_, address_);
+  if (fd < 0) {
+    return false;
+  }
+
+  // Verify chip ID
+  int chip_id = readRegister(fd, Bmi160Reg::CHIP_ID);
+  if (chip_id != 0xD1) {
+    RCLCPP_ERROR(
+      logger_, "BMI160: unexpected chip ID 0x%02X (expected 0xD1). "
+      "Check wiring and I2C address.", chip_id);
+    close(fd);
+    return false;
+  }
+
+  // Power up accelerometer and gyroscope (each takes ~50 ms to settle)
+  writeRegister(fd, Bmi160Reg::CMD, Bmi160Cmd::ACCEL_NORMAL);
+  std::this_thread::sleep_for(std::chrono::milliseconds(80));
+  writeRegister(fd, Bmi160Reg::CMD, Bmi160Cmd::GYRO_NORMAL);
+  std::this_thread::sleep_for(std::chrono::milliseconds(80));
+
+  close(fd);
+  RCLCPP_INFO(logger_, "BMI160: chip ID verified (0xD1), powered up on bus %d addr 0x%02X",
+    bus_id_, address_);
+  return true;
+}
+
+void BMI160::configure(int accel_range_g, int gyro_range_dps)
+{
+  int fd = openDevice(bus_id_, address_);
+  if (fd < 0) {return;}
+
+  // --- Accelerometer ---
+  uint8_t accel_range_reg = 0x05;  // default: ±4G
+  for (const auto & entry : ACCEL_RANGES) {
+    if (entry.g == accel_range_g) {
+      accel_range_reg = entry.reg_val;
+      break;
+    }
+  }
+  // ACC_CONF: ODR 100 Hz (0x08) + normal bandwidth filter (0x20)
+  writeRegister(fd, Bmi160Reg::ACC_CONF, 0x28);   // odr=100Hz, bwp=normal
+  writeRegister(fd, Bmi160Reg::ACC_RANGE, accel_range_reg);
+  accel_scale_ = conversions::computeAccelScale(accel_range_g);
+
+  // --- Gyroscope ---
+  uint8_t gyro_range_reg = 0x03;  // default: ±250 dps
+  for (const auto & entry : GYRO_RANGES) {
+    if (entry.dps == gyro_range_dps) {
+      gyro_range_reg = entry.reg_val;
+      break;
+    }
+  }
+  // GYR_CONF: ODR 100 Hz + normal bandwidth
+  writeRegister(fd, Bmi160Reg::GYR_CONF, 0x28);
+  writeRegister(fd, Bmi160Reg::GYR_RANGE, gyro_range_reg);
+  gyro_scale_ = conversions::computeGyroScale(gyro_range_dps);
+
+  close(fd);
+  RCLCPP_INFO(
+    logger_, "BMI160: configured accel ±%dG (scale=%.6f m/s²/LSB), "
+    "gyro ±%ddps (scale=%.8f rad/s/LSB)",
+    accel_range_g, accel_scale_, gyro_range_dps, gyro_scale_);
+}
+
+void BMI160::calibrate(int z_gravity_target)
+{
+  int fd = openDevice(bus_id_, address_);
+  if (fd < 0) {return;}
+
+  // FOC_CONF register layout (datasheet section 2.12.3):
+  //   bits [7:6] foc_acc_z  : 0b01 = calibrate to +1g, 0b10 = calibrate to -1g
+  //   bits [5:4] foc_acc_y  : 0b00 = disabled (offset to 0g)
+  //   bits [3:2] foc_acc_x  : 0b00 = disabled (offset to 0g)
+  //   bit  [1]   foc_gyr_en : 1 = enable gyro FOC
+  //
+  // For X and Y: 0b01 = +0g target (same encoding), for Z: 0b01=+1g, 0b10=-1g
+  // X offset to 0g = 0b01, Y offset to 0g = 0b01
+  // Encoding for z: target=+1 → 0b01, target=-1 → 0b10
+
+  uint8_t foc_acc_z = (z_gravity_target >= 0) ? 0x01 : 0x02;
+  // foc_acc_x = 0b01 (0g), foc_acc_y = 0b01 (0g), foc_gyr_en = 1
+  uint8_t foc_conf = static_cast<uint8_t>(
+    (foc_acc_z << 6) | (0x01 << 4) | (0x01 << 2) | 0x02);
+
+  writeRegister(fd, Bmi160Reg::FOC_CONF, foc_conf);
+  // Trigger FOC
+  writeRegister(fd, Bmi160Reg::CMD, Bmi160Cmd::START_FOC);
+  // FOC completes in ~250 ms (datasheet)
+  std::this_thread::sleep_for(std::chrono::milliseconds(300));
+
+  // Enable offset compensation (OFFSET_6 bit 6 = acc_off_en, bit 7 = gyr_off_en)
+  int cur = readRegister(fd, Bmi160Reg::OFFSET_6);
+  if (cur >= 0) {
+    writeRegister(fd, Bmi160Reg::OFFSET_6, static_cast<uint8_t>(cur) | 0xC0);
+  }
+
+  close(fd);
+  RCLCPP_INFO(logger_, "BMI160: FOC calibration done (z target: %+dg)", z_gravity_target);
+}
+
+void BMI160::configureHighGInterrupt(float threshold_g)
+{
+  int fd = openDevice(bus_id_, address_);
+  if (fd < 0) {return;}
+
+  // INT_EN_1: bits [5:3] = high_g_en_x/y/z — enable for all three axes
+  writeRegister(fd, Bmi160Reg::INT_EN_1, 0x38);
+
+  // INT_LOWHIGH_2 (0x5E): high_g_dur — duration = 0 means 1 sample (immediate)
+  writeRegister(fd, Bmi160Reg::INT_LOWHIGH_2, 0x00);
+
+  // INT_LOWHIGH_3 (0x5F): high_g_thres — 1 LSB = 7.81 mg
+  uint8_t thresh_reg = conversions::encodeHighGThreshold(threshold_g);
+  writeRegister(fd, Bmi160Reg::INT_LOWHIGH_3, thresh_reg);
+
+  // INT_LOWHIGH_4 (0x60): high_g_hyst — set to small value (1 LSB = 15.63 mg)
+  writeRegister(fd, Bmi160Reg::INT_LOWHIGH_4, 0x03);
+
+  close(fd);
+  RCLCPP_INFO(
+    logger_, "BMI160: high-G interrupt enabled, threshold=%.2fG (reg=0x%02X)",
+    threshold_g, thresh_reg);
+}
+
+bool BMI160::readMotion6(
+  int16_t & gx, int16_t & gy, int16_t & gz,
+  int16_t & ax, int16_t & ay, int16_t & az)
+{
+  int fd = openDevice(bus_id_, address_);
+  if (fd < 0) {return false;}
+
+  // 12 bytes starting at DATA_GYR_X_L (0x0C):
+  //   [0..1] GX, [2..3] GY, [4..5] GZ, [6..7] AX, [8..9] AY, [10..11] AZ
+  uint8_t buf[12];
+  bool ok = readRegisters(fd, Bmi160Reg::DATA_GYR_X_L, 12, buf);
+  close(fd);
+
+  if (!ok) {return false;}
+
+  gx = static_cast<int16_t>((buf[1] << 8) | buf[0]);
+  gy = static_cast<int16_t>((buf[3] << 8) | buf[2]);
+  gz = static_cast<int16_t>((buf[5] << 8) | buf[4]);
+  ax = static_cast<int16_t>((buf[7] << 8) | buf[6]);
+  ay = static_cast<int16_t>((buf[9] << 8) | buf[8]);
+  az = static_cast<int16_t>((buf[11] << 8) | buf[10]);
+  return true;
+}
+
+bool BMI160::isHighGTriggered()
+{
+  int fd = openDevice(bus_id_, address_);
+  if (fd < 0) {return false;}
+
+  // INT_STATUS_1 (0x1D): bit 2 = high_g_int
+  int status = readRegister(fd, Bmi160Reg::INT_STATUS_1);
+  close(fd);
+
+  if (status < 0) {return false;}
+  return (static_cast<uint8_t>(status) & 0x04) != 0;
+}
+
+}  // namespace imu_pkg

--- a/src/aws-deepracer-community-imu-pkg/src/bmi160.cpp
+++ b/src/aws-deepracer-community-imu-pkg/src/bmi160.cpp
@@ -207,19 +207,23 @@ void BMI160::calibrate(int z_gravity_target)
   if (fd < 0) {return;}
 
   // FOC_CONF register layout (datasheet section 2.12.3):
-  //   bits [7:6] foc_acc_z  : 0b01 = calibrate to +1g, 0b10 = calibrate to -1g
-  //   bits [5:4] foc_acc_y  : 0b00 = disabled (offset to 0g)
-  //   bits [3:2] foc_acc_x  : 0b00 = disabled (offset to 0g)
+  //   bits [7:6] foc_acc_z  : 0b01 = sensor target +1g, 0b10 = sensor target -1g, 0b11 = 0g
+  //   bits [5:4] foc_acc_y  : same encoding
+  //   bits [3:2] foc_acc_x  : same encoding
   //   bit  [1]   foc_gyr_en : 1 = enable gyro FOC
   //
-  // For X and Y: 0b01 = +0g target (same encoding), for Z: 0b01=+1g, 0b10=-1g
-  // X offset to 0g = 0b01, Y offset to 0g = 0b01
-  // Encoding for z: target=+1 → 0b01, target=-1 → 0b10
+  // The z_gravity_target parameter represents the EXPECTED PUBLISHED accel_z direction.
+  // Since the axis mapping inverts Z (published_z = -raw_z), the raw sensor target
+  // is the OPPOSITE of the published target:
+  //   z_gravity_target = +1 (upside-down, published z ≈ +g) → sensor reads -1g → target 0b10
+  //   z_gravity_target = -1 (normal mount, published z ≈ -g) → sensor reads +1g → target 0b01
+  //
+  // X and Y: 0g target = 0b11 (0x03). NOT 0b01 (which is +1g).
 
-  uint8_t foc_acc_z = (z_gravity_target >= 0) ? 0x01 : 0x02;
-  // foc_acc_x = 0b01 (0g), foc_acc_y = 0b01 (0g), foc_gyr_en = 1
+  uint8_t foc_acc_z = (z_gravity_target >= 0) ? 0x02 : 0x01;
+  // foc_acc_x = 0b11 (0g), foc_acc_y = 0b11 (0g), foc_gyr_en = 1
   uint8_t foc_conf = static_cast<uint8_t>(
-    (foc_acc_z << 6) | (0x01 << 4) | (0x01 << 2) | 0x02);
+    (foc_acc_z << 6) | (0x03 << 4) | (0x03 << 2) | 0x02);
 
   writeRegister(fd, Bmi160Reg::FOC_CONF, foc_conf);
   // Trigger FOC

--- a/src/aws-deepracer-community-imu-pkg/src/bmi160.cpp
+++ b/src/aws-deepracer-community-imu-pkg/src/bmi160.cpp
@@ -176,8 +176,9 @@ void BMI160::configure(int accel_range_g, int gyro_range_dps)
       break;
     }
   }
-  // ACC_CONF: ODR 100 Hz (0x08) + normal bandwidth filter (0x20)
-  writeRegister(fd, Bmi160Reg::ACC_CONF, 0x28);   // odr=100Hz, bwp=normal
+  // ACC_CONF: ODR 100 Hz, bwp=OSR4 (oversampling ×4, halves noise floor)
+  // 0x08 = bwp[6:4]=0b000 (OSR4) | odr[3:0]=0b1000 (100Hz)
+  writeRegister(fd, Bmi160Reg::ACC_CONF, 0x08);
   writeRegister(fd, Bmi160Reg::ACC_RANGE, accel_range_reg);
   accel_scale_ = conversions::computeAccelScale(accel_range_g);
 
@@ -189,8 +190,9 @@ void BMI160::configure(int accel_range_g, int gyro_range_dps)
       break;
     }
   }
-  // GYR_CONF: ODR 100 Hz + normal bandwidth
-  writeRegister(fd, Bmi160Reg::GYR_CONF, 0x28);
+  // GYR_CONF: ODR 100 Hz, bwp=OSR4 (oversampling ×4, halves noise floor)
+  // 0x08 = bwp[5:4]=0b00 (OSR4) | odr[3:0]=0b1000 (100Hz)
+  writeRegister(fd, Bmi160Reg::GYR_CONF, 0x08);
   writeRegister(fd, Bmi160Reg::GYR_RANGE, gyro_range_reg);
   gyro_scale_ = conversions::computeGyroScale(gyro_range_dps);
 

--- a/src/aws-deepracer-community-imu-pkg/src/imu_node.cpp
+++ b/src/aws-deepracer-community-imu-pkg/src/imu_node.cpp
@@ -1,0 +1,257 @@
+///////////////////////////////////////////////////////////////////////////////////
+//   Copyright AWS DeepRacer Community. All Rights Reserved.                    //
+//                                                                               //
+//   Licensed under the Apache License, Version 2.0 (the "License").             //
+//   You may not use this file except in compliance with the License.            //
+//   You may obtain a copy of the License at                                     //
+//                                                                               //
+//       http://www.apache.org/licenses/LICENSE-2.0                              //
+//                                                                               //
+//   Unless required by applicable law or agreed to in writing, software         //
+//   distributed under the License is distributed on an "AS IS" BASIS,           //
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    //
+//   See the License for the specific language governing permissions and         //
+//   limitations under the License.                                              //
+///////////////////////////////////////////////////////////////////////////////////
+
+#include "imu_pkg/imu_node.hpp"
+#include "imu_pkg/conversions.hpp"
+
+#include <cmath>
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace imu_pkg
+{
+
+// -------------------------------------------------------------------------
+// Topic / service names
+// -------------------------------------------------------------------------
+static constexpr char IMU_TOPIC[] = "imu_msg/data_raw";
+static constexpr char VEHICLE_STATE_SRV[] = "/ctrl_pkg/enable_state";
+
+// Default I2C bus per hardware platform
+#if defined(HW_PLATFORM_DR)
+static constexpr int DEFAULT_BUS_ID = 7;
+#else
+static constexpr int DEFAULT_BUS_ID = 1;  // RPI or unknown
+#endif
+
+// -------------------------------------------------------------------------
+// Constructor
+// -------------------------------------------------------------------------
+ImuNode::ImuNode()
+: Node("imu_node")
+{
+  RCLCPP_INFO(get_logger(), "IMU node starting...");
+
+  // --- Declare parameters ---
+  declare_parameter<int>("bus_id", DEFAULT_BUS_ID);
+  declare_parameter<int>("address", 0x68);
+  declare_parameter<int>("publish_rate", 25);
+  declare_parameter<int>("accel_range_g", 4);
+  declare_parameter<int>("gyro_range_dps", 250);
+  declare_parameter<int>("accel_z_gravity_target", -1);
+  declare_parameter<bool>("stop_on_pickup", false);
+  declare_parameter<bool>("stop_on_crash", false);
+  declare_parameter<double>("crash_accel_threshold_g", 3.0);
+  declare_parameter<double>("pickup_threshold_g", 0.5);
+
+  // --- Cache parameters ---
+  bus_id_ = get_parameter("bus_id").as_int();
+  address_ = get_parameter("address").as_int();
+  publish_rate_ = get_parameter("publish_rate").as_int();
+  accel_range_g_ = get_parameter("accel_range_g").as_int();
+  gyro_range_dps_ = get_parameter("gyro_range_dps").as_int();
+  accel_z_gravity_target_ = get_parameter("accel_z_gravity_target").as_int();
+  stop_on_pickup_ = get_parameter("stop_on_pickup").as_bool();
+  stop_on_crash_ = get_parameter("stop_on_crash").as_bool();
+  crash_accel_threshold_g_ = get_parameter("crash_accel_threshold_g").as_double();
+  pickup_threshold_g_ = get_parameter("pickup_threshold_g").as_double();
+
+  RCLCPP_INFO(
+    get_logger(),
+    "Parameters: bus=%d addr=0x%02X rate=%dHz accel=±%dG gyro=±%ddps "
+    "z_target=%+d stop_on_pickup=%s stop_on_crash=%s",
+    bus_id_, address_, publish_rate_, accel_range_g_, gyro_range_dps_,
+    accel_z_gravity_target_,
+    stop_on_pickup_ ? "true" : "false",
+    stop_on_crash_ ? "true" : "false");
+
+  // --- Publisher ---
+  auto qos = rclcpp::QoS(rclcpp::KeepLast(1)).best_effort();
+  imu_publisher_ = create_publisher<sensor_msgs::msg::Imu>(IMU_TOPIC, qos);
+
+  // --- Vehicle-state service client (only if stop features enabled) ---
+  if (stop_on_pickup_ || stop_on_crash_) {
+    auto cb_group = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+    vehicle_state_client_ =
+      create_client<deepracer_interfaces_pkg::srv::EnableStateSrv>(
+        VEHICLE_STATE_SRV, rclcpp::SystemDefaultsQoS(), cb_group);
+    RCLCPP_INFO(get_logger(), "Safety stop features enabled; waiting for %s ...",
+      VEHICLE_STATE_SRV);
+  }
+
+  // --- Initialise sensor ---
+  if (!initSensor()) {
+    RCLCPP_ERROR(get_logger(), "IMU sensor initialisation failed — node will not publish");
+    return;
+  }
+
+  // --- Publish timer ---
+  auto period_ms = std::chrono::milliseconds(1000 / publish_rate_);
+  publish_timer_ = create_timer(
+    period_ms, std::bind(&ImuNode::timerCallback, this));
+
+  // --- Heartbeat timer (5 s) ---
+  heartbeat_timer_ = create_timer(
+    std::chrono::seconds(5), std::bind(&ImuNode::heartbeatCallback, this));
+
+  RCLCPP_INFO(get_logger(), "IMU node started, publishing at %d Hz", publish_rate_);
+}
+
+// -------------------------------------------------------------------------
+// Sensor initialisation
+// -------------------------------------------------------------------------
+bool ImuNode::initSensor()
+{
+  imu_ = std::make_unique<BMI160>(get_logger());
+
+  if (!imu_->init(bus_id_, address_)) {
+    return false;
+  }
+
+  imu_->configure(accel_range_g_, gyro_range_dps_);
+  imu_->calibrate(accel_z_gravity_target_);
+
+  if (stop_on_crash_) {
+    imu_->configureHighGInterrupt(static_cast<float>(crash_accel_threshold_g_));
+  }
+
+  return true;
+}
+
+// -------------------------------------------------------------------------
+// Timer callback — runs at publish_rate_ Hz
+// -------------------------------------------------------------------------
+void ImuNode::timerCallback()
+{
+  int16_t raw_gx, raw_gy, raw_gz, raw_ax, raw_ay, raw_az;
+  if (!imu_->readMotion6(raw_gx, raw_gy, raw_gz, raw_ax, raw_ay, raw_az)) {
+    RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 5000,
+      "IMU read failed, skipping frame");
+    return;
+  }
+
+  const auto data = conversions::applyAxisMapping(
+    raw_gx, raw_gy, raw_gz, raw_ax, raw_ay, raw_az,
+    imu_->accel_scale(), imu_->gyro_scale());
+
+  const float gyro_x = data.gyro_x;
+  const float gyro_y = data.gyro_y;
+  const float gyro_z = data.gyro_z;
+  const float accel_x = data.accel_x;
+  const float accel_y = data.accel_y;
+  const float accel_z = data.accel_z;
+
+  // --- Safety checks (before publishing) ---
+  if (stop_on_crash_ && imu_->isHighGTriggered()) {
+    triggerStop("crash");
+  }
+
+  if (stop_on_pickup_) {
+    if (conversions::isPickupDetected(
+        static_cast<double>(accel_z), accel_z_gravity_target_, pickup_threshold_g_))
+    {
+      triggerStop("pickup");
+    }
+  }
+
+  // --- Publish only when there are active subscribers ---
+  if (imu_publisher_->get_subscription_count() == 0) {
+    return;
+  }
+
+  sensor_msgs::msg::Imu msg;
+  msg.header.stamp = now();
+  msg.header.frame_id = "base_link";
+
+  msg.angular_velocity.x = gyro_x;
+  msg.angular_velocity.y = gyro_y;
+  msg.angular_velocity.z = gyro_z;
+  // Diagonal covariance 0.01; off-diagonals 0
+  msg.angular_velocity_covariance = {
+    0.01, 0.0, 0.0,
+    0.0, 0.01, 0.0,
+    0.0, 0.0, 0.01};
+
+  msg.linear_acceleration.x = accel_x;
+  msg.linear_acceleration.y = accel_y;
+  msg.linear_acceleration.z = accel_z;
+  msg.linear_acceleration_covariance = {
+    0.01, 0.0, 0.0,
+    0.0, 0.01, 0.0,
+    0.0, 0.0, 0.01};
+
+  // Orientation unknown — signal this with covariance[0] = -1
+  msg.orientation_covariance[0] = -1.0;
+
+  RCLCPP_DEBUG(get_logger(), "gyro(%.2f, %.2f, %.2f) accel(%.2f, %.2f, %.2f)",
+    gyro_x, gyro_y, gyro_z, accel_x, accel_y, accel_z);
+
+  imu_publisher_->publish(msg);
+}
+
+// -------------------------------------------------------------------------
+// Safety stop
+// -------------------------------------------------------------------------
+void ImuNode::triggerStop(const std::string & reason)
+{
+  RCLCPP_WARN(get_logger(), "IMU safety stop triggered: %s", reason.c_str());
+
+  if (!vehicle_state_client_) {
+    RCLCPP_ERROR(get_logger(),
+      "triggerStop called but vehicle_state client is not initialised");
+    return;
+  }
+
+  if (!vehicle_state_client_->service_is_ready()) {
+    RCLCPP_ERROR(get_logger(),
+      "vehicle_state service not available — cannot stop vehicle");
+    return;
+  }
+
+  auto request = std::make_shared<deepracer_interfaces_pkg::srv::EnableStateSrv::Request>();
+  request->is_active = false;
+
+  // Fire-and-forget async call; we do not need the response.
+  vehicle_state_client_->async_send_request(request);
+}
+
+// -------------------------------------------------------------------------
+// Heartbeat
+// -------------------------------------------------------------------------
+void ImuNode::heartbeatCallback()
+{
+  RCLCPP_DEBUG(get_logger(), "IMU heartbeat #%d", ++heartbeat_count_);
+}
+
+}  // namespace imu_pkg
+
+// -------------------------------------------------------------------------
+// main
+// -------------------------------------------------------------------------
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+
+  auto node = std::make_shared<imu_pkg::ImuNode>();
+
+  rclcpp::executors::MultiThreadedExecutor executor;
+  executor.add_node(node);
+  executor.spin();
+
+  rclcpp::shutdown();
+  return 0;
+}

--- a/src/aws-deepracer-community-imu-pkg/src/imu_node.cpp
+++ b/src/aws-deepracer-community-imu-pkg/src/imu_node.cpp
@@ -225,9 +225,14 @@ void ImuNode::timerCallback()
 // -------------------------------------------------------------------------
 void ImuNode::triggerStop(const std::string & reason)
 {
-  RCLCPP_WARN(get_logger(), "[TEST] IMU safety stop triggered: %s — skipping service call", reason.c_str());
-  // TODO: remove test mode and restore service call
-  return;
+  // Throttle: suppress log and service call if fired within the last second
+  const rclcpp::Time now_t = now();
+  if ((now_t - last_stop_time_).seconds() < 1.0) {
+    return;
+  }
+  last_stop_time_ = now_t;
+
+  RCLCPP_WARN(get_logger(), "IMU safety stop triggered: %s", reason.c_str());
 
   if (!vehicle_state_client_) {
     RCLCPP_ERROR(get_logger(),

--- a/src/aws-deepracer-community-imu-pkg/src/imu_node.cpp
+++ b/src/aws-deepracer-community-imu-pkg/src/imu_node.cpp
@@ -50,8 +50,8 @@ ImuNode::ImuNode()
   declare_parameter<int>("bus_id", DEFAULT_BUS_ID);
   declare_parameter<int>("address", 0x68);
   declare_parameter<int>("publish_rate", 30);
-  declare_parameter<int>("accel_range_g", 4);
-  declare_parameter<int>("gyro_range_dps", 250);
+  declare_parameter<int>("accel_range_g", 8);
+  declare_parameter<int>("gyro_range_dps", 1000);
   declare_parameter<int>("accel_z_gravity_target", 1);  // +1 for upside-down (DeepRacer default), -1 for normal mount
   declare_parameter<bool>("stop_on_pickup", false);
   declare_parameter<bool>("stop_on_crash", false);

--- a/src/aws-deepracer-community-imu-pkg/src/imu_node.cpp
+++ b/src/aws-deepracer-community-imu-pkg/src/imu_node.cpp
@@ -23,6 +23,8 @@
 #include <memory>
 #include <string>
 
+#include "std_msgs/msg/string.hpp"
+
 namespace imu_pkg
 {
 
@@ -30,14 +32,11 @@ namespace imu_pkg
 // Topic / service names
 // -------------------------------------------------------------------------
 static constexpr char IMU_TOPIC[] = "imu_msg/data_raw";
+static constexpr char IMU_SAFETY_EVENT_TOPIC[] = "safety_event";
 static constexpr char VEHICLE_STATE_SRV[] = "/ctrl_pkg/enable_state";
 
-// Default I2C bus per hardware platform
-#if defined(HW_PLATFORM_DR)
-static constexpr int DEFAULT_BUS_ID = 7;
-#else
-static constexpr int DEFAULT_BUS_ID = 1;  // RPI or unknown
-#endif
+// Default I2C bus (bus 1 on both original DeepRacer and Raspberry Pi)
+static constexpr int DEFAULT_BUS_ID = 1;
 
 // -------------------------------------------------------------------------
 // Constructor
@@ -86,6 +85,8 @@ ImuNode::ImuNode()
   // --- Publisher ---
   auto qos = rclcpp::QoS(rclcpp::KeepLast(1)).best_effort();
   imu_publisher_ = create_publisher<sensor_msgs::msg::Imu>(IMU_TOPIC, qos);
+  safety_event_publisher_ = create_publisher<std_msgs::msg::String>(
+    IMU_SAFETY_EVENT_TOPIC, rclcpp::QoS(10).reliable());
 
   // --- Vehicle-state service client (only if stop features enabled) ---
   if (stop_on_pickup_ || stop_on_crash_) {
@@ -235,6 +236,11 @@ void ImuNode::triggerStop(const std::string & reason)
   last_stop_time_ = now_t;
 
   RCLCPP_WARN(get_logger(), "IMU safety stop triggered: %s", reason.c_str());
+
+  // Publish the safety event for the UI.
+  auto event_msg = std_msgs::msg::String();
+  event_msg.data = reason;
+  safety_event_publisher_->publish(event_msg);
 
   if (!vehicle_state_client_) {
     RCLCPP_ERROR(get_logger(),

--- a/src/aws-deepracer-community-imu-pkg/src/imu_node.cpp
+++ b/src/aws-deepracer-community-imu-pkg/src/imu_node.cpp
@@ -17,6 +17,7 @@
 #include "imu_pkg/imu_node.hpp"
 #include "imu_pkg/conversions.hpp"
 
+#include <algorithm>
 #include <cmath>
 #include <functional>
 #include <memory>
@@ -103,6 +104,7 @@ ImuNode::ImuNode()
   }
 
   // --- Publish timer ---
+  publish_rate_ = std::max(1, publish_rate_);  // guard against divide-by-zero
   auto period_ms = std::chrono::milliseconds(1000 / publish_rate_);
   publish_timer_ = create_timer(
     period_ms, std::bind(&ImuNode::timerCallback, this));

--- a/src/aws-deepracer-community-imu-pkg/src/imu_node.cpp
+++ b/src/aws-deepracer-community-imu-pkg/src/imu_node.cpp
@@ -57,6 +57,7 @@ ImuNode::ImuNode()
   declare_parameter<bool>("stop_on_crash", false);
   declare_parameter<double>("crash_accel_threshold_g", 3.0);
   declare_parameter<double>("pickup_threshold_g", 0.5);
+  declare_parameter<double>("filter_alpha", 0.5);  // EMA: 1.0=off, lower=smoother
 
   // --- Cache parameters ---
   bus_id_ = get_parameter("bus_id").as_int();
@@ -69,15 +70,17 @@ ImuNode::ImuNode()
   stop_on_crash_ = get_parameter("stop_on_crash").as_bool();
   crash_accel_threshold_g_ = get_parameter("crash_accel_threshold_g").as_double();
   pickup_threshold_g_ = get_parameter("pickup_threshold_g").as_double();
+  filter_alpha_ = std::clamp(get_parameter("filter_alpha").as_double(), 0.0, 1.0);
 
   RCLCPP_INFO(
     get_logger(),
     "Parameters: bus=%d addr=0x%02X rate=%dHz accel=±%dG gyro=±%ddps "
-    "z_target=%+d stop_on_pickup=%s stop_on_crash=%s",
+    "z_target=%+d stop_on_pickup=%s stop_on_crash=%s filter_alpha=%.2f",
     bus_id_, address_, publish_rate_, accel_range_g_, gyro_range_dps_,
     accel_z_gravity_target_,
     stop_on_pickup_ ? "true" : "false",
-    stop_on_crash_ ? "true" : "false");
+    stop_on_crash_ ? "true" : "false",
+    filter_alpha_);
 
   // --- Publisher ---
   auto qos = rclcpp::QoS(rclcpp::KeepLast(1)).best_effort();
@@ -144,16 +147,27 @@ void ImuNode::timerCallback()
     return;
   }
 
-  const auto data = conversions::applyAxisMapping(
+  const auto raw = conversions::applyAxisMapping(
     raw_gx, raw_gy, raw_gz, raw_ax, raw_ay, raw_az,
     imu_->accel_scale(), imu_->gyro_scale());
 
-  const float gyro_x = data.gyro_x;
-  const float gyro_y = data.gyro_y;
-  const float gyro_z = data.gyro_z;
-  const float accel_x = data.accel_x;
-  const float accel_y = data.accel_y;
-  const float accel_z = data.accel_z;
+  // Apply software EMA filter (alpha=1.0 means pass-through)
+  float gyro_x, gyro_y, gyro_z, accel_x, accel_y, accel_z;
+  if (!filter_initialized_ || filter_alpha_ >= 1.0) {
+    gyro_x = raw.gyro_x; gyro_y = raw.gyro_y; gyro_z = raw.gyro_z;
+    accel_x = raw.accel_x; accel_y = raw.accel_y; accel_z = raw.accel_z;
+    filter_initialized_ = true;
+  } else {
+    const float a = static_cast<float>(filter_alpha_);
+    gyro_x = conversions::ema(raw.gyro_x, prev_gyro_x_, a);
+    gyro_y = conversions::ema(raw.gyro_y, prev_gyro_y_, a);
+    gyro_z = conversions::ema(raw.gyro_z, prev_gyro_z_, a);
+    accel_x = conversions::ema(raw.accel_x, prev_accel_x_, a);
+    accel_y = conversions::ema(raw.accel_y, prev_accel_y_, a);
+    accel_z = conversions::ema(raw.accel_z, prev_accel_z_, a);
+  }
+  prev_gyro_x_ = gyro_x; prev_gyro_y_ = gyro_y; prev_gyro_z_ = gyro_z;
+  prev_accel_x_ = accel_x; prev_accel_y_ = accel_y; prev_accel_z_ = accel_z;
 
   // --- Safety checks (before publishing) ---
   if (stop_on_crash_ && imu_->isHighGTriggered()) {

--- a/src/aws-deepracer-community-imu-pkg/src/imu_node.cpp
+++ b/src/aws-deepracer-community-imu-pkg/src/imu_node.cpp
@@ -128,9 +128,9 @@ bool ImuNode::initSensor()
   imu_->configure(accel_range_g_, gyro_range_dps_);
   imu_->calibrate(accel_z_gravity_target_);
 
-  if (stop_on_crash_) {
-    imu_->configureHighGInterrupt(static_cast<float>(crash_accel_threshold_g_));
-  }
+  // Hardware high-G interrupt not used for crash detection (software magnitude
+  // check in timerCallback is more reliable at 30 Hz polling). Retained in
+  // BMI160 driver for future GPIO-based use.
 
   return true;
 }
@@ -170,7 +170,10 @@ void ImuNode::timerCallback()
   prev_accel_x_ = accel_x; prev_accel_y_ = accel_y; prev_accel_z_ = accel_z;
 
   // --- Safety checks (before publishing) ---
-  if (stop_on_crash_ && imu_->isHighGTriggered()) {
+  if (stop_on_crash_ && conversions::isCrashDetected(
+      static_cast<double>(accel_x), static_cast<double>(accel_y),
+      static_cast<double>(accel_z), crash_accel_threshold_g_))
+  {
     triggerStop("crash");
   }
 

--- a/src/aws-deepracer-community-imu-pkg/src/imu_node.cpp
+++ b/src/aws-deepracer-community-imu-pkg/src/imu_node.cpp
@@ -222,7 +222,9 @@ void ImuNode::timerCallback()
 // -------------------------------------------------------------------------
 void ImuNode::triggerStop(const std::string & reason)
 {
-  RCLCPP_WARN(get_logger(), "IMU safety stop triggered: %s", reason.c_str());
+  RCLCPP_WARN(get_logger(), "[TEST] IMU safety stop triggered: %s — skipping service call", reason.c_str());
+  // TODO: remove test mode and restore service call
+  return;
 
   if (!vehicle_state_client_) {
     RCLCPP_ERROR(get_logger(),

--- a/src/aws-deepracer-community-imu-pkg/src/imu_node.cpp
+++ b/src/aws-deepracer-community-imu-pkg/src/imu_node.cpp
@@ -52,7 +52,7 @@ ImuNode::ImuNode()
   declare_parameter<int>("publish_rate", 25);
   declare_parameter<int>("accel_range_g", 4);
   declare_parameter<int>("gyro_range_dps", 250);
-  declare_parameter<int>("accel_z_gravity_target", -1);
+  declare_parameter<int>("accel_z_gravity_target", 1);  // +1 for upside-down (DeepRacer default), -1 for normal mount
   declare_parameter<bool>("stop_on_pickup", false);
   declare_parameter<bool>("stop_on_crash", false);
   declare_parameter<double>("crash_accel_threshold_g", 3.0);

--- a/src/aws-deepracer-community-imu-pkg/src/imu_node.cpp
+++ b/src/aws-deepracer-community-imu-pkg/src/imu_node.cpp
@@ -49,7 +49,7 @@ ImuNode::ImuNode()
   // --- Declare parameters ---
   declare_parameter<int>("bus_id", DEFAULT_BUS_ID);
   declare_parameter<int>("address", 0x68);
-  declare_parameter<int>("publish_rate", 25);
+  declare_parameter<int>("publish_rate", 30);
   declare_parameter<int>("accel_range_g", 4);
   declare_parameter<int>("gyro_range_dps", 250);
   declare_parameter<int>("accel_z_gravity_target", 1);  // +1 for upside-down (DeepRacer default), -1 for normal mount

--- a/src/aws-deepracer-community-imu-pkg/test/test_conversions.cpp
+++ b/src/aws-deepracer-community-imu-pkg/test/test_conversions.cpp
@@ -1,0 +1,364 @@
+///////////////////////////////////////////////////////////////////////////////////
+//   Copyright AWS DeepRacer Community. All Rights Reserved.                    //
+//                                                                               //
+//   Licensed under the Apache License, Version 2.0 (the "License").             //
+//   You may not use this file except in compliance with the License.            //
+//   You may obtain a copy of the License at                                     //
+//                                                                               //
+//       http://www.apache.org/licenses/LICENSE-2.0                              //
+//                                                                               //
+//   Unless required by applicable law or agreed to in writing, software         //
+//   distributed under the License is distributed on an "AS IS" BASIS,           //
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    //
+//   See the License for the specific language governing permissions and         //
+//   limitations under the License.                                              //
+///////////////////////////////////////////////////////////////////////////////////
+
+#include <gtest/gtest.h>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+
+#include "imu_pkg/conversions.hpp"
+#include "imu_pkg/bmi160.hpp"   // for Bmi160Reg constants
+
+using namespace imu_pkg::conversions;
+using namespace imu_pkg;
+
+// =========================================================================
+// Scale factor computation
+// =========================================================================
+
+class AccelScaleTest : public ::testing::Test {};
+
+/// Known good values derived from the BMI160 datasheet:
+///   ±4G range → sensitivity = 8192 LSB/G → scale = 9.80665 / 8192
+TEST_F(AccelScaleTest, FourGRange)
+{
+  const float scale = computeAccelScale(4);
+  // 9.80665 / 8192 ≈ 0.001197 m/s²/LSB
+  EXPECT_NEAR(scale, 9.80665f / 8192.0f, 1e-6f);
+}
+
+TEST_F(AccelScaleTest, TwoGRange)
+{
+  const float scale = computeAccelScale(2);
+  EXPECT_NEAR(scale, 9.80665f / 16384.0f, 1e-6f);
+}
+
+TEST_F(AccelScaleTest, EightGRange)
+{
+  const float scale = computeAccelScale(8);
+  EXPECT_NEAR(scale, 9.80665f / 4096.0f, 1e-6f);
+}
+
+TEST_F(AccelScaleTest, SixteenGRange)
+{
+  const float scale = computeAccelScale(16);
+  EXPECT_NEAR(scale, 9.80665f / 2048.0f, 1e-6f);
+}
+
+/// Verify that at ±4G, a raw value of 8192 converts to ≈ 1G (9.80665 m/s²)
+TEST_F(AccelScaleTest, OneGEquivalence)
+{
+  const float scale = computeAccelScale(4);
+  const float one_g = 8192.0f * scale;
+  EXPECT_NEAR(one_g, 9.80665f, 1e-4f);
+}
+
+// -------------------------------------------------------------------------
+
+class GyroScaleTest : public ::testing::Test {};
+
+/// Known good: ±250 dps → sensitivity = 131.072 LSB/(°/s)
+///   scale = (π/180) / 131.072
+TEST_F(GyroScaleTest, TwoFiftyDps)
+{
+  const float scale = computeGyroScale(250);
+  EXPECT_NEAR(scale, (static_cast<float>(M_PI) / 180.0f) / (32768.0f / 250.0f), 1e-9f);
+}
+
+TEST_F(GyroScaleTest, OneTwentyFiveDps)
+{
+  const float scale = computeGyroScale(125);
+  EXPECT_NEAR(scale, (static_cast<float>(M_PI) / 180.0f) / (32768.0f / 125.0f), 1e-9f);
+}
+
+TEST_F(GyroScaleTest, FiveHundredDps)
+{
+  const float scale = computeGyroScale(500);
+  EXPECT_NEAR(scale, (static_cast<float>(M_PI) / 180.0f) / (32768.0f / 500.0f), 1e-9f);
+}
+
+/// 32768 LSB at ±250dps should equal 250 deg/s = 250×π/180 rad/s
+TEST_F(GyroScaleTest, FullScaleEquivalence)
+{
+  const float scale = computeGyroScale(250);
+  const float full_scale_rads = 32768.0f * scale;
+  EXPECT_NEAR(full_scale_rads, 250.0f * static_cast<float>(M_PI) / 180.0f, 1e-3f);
+}
+
+// =========================================================================
+// High-G threshold register encoding
+// =========================================================================
+
+class HighGThreshTest : public ::testing::Test {};
+
+/// 3G → 3 / 0.00781 ≈ 384, but register is uint8 so must be clamped
+TEST_F(HighGThreshTest, ThreeG)
+{
+  const uint8_t reg = encodeHighGThreshold(3.0f);
+  // 3.0 / 0.00781 ≈ 384.2 → clamped to 255
+  EXPECT_EQ(reg, 255u);
+}
+
+/// 1G → 1 / 0.00781 ≈ 128
+TEST_F(HighGThreshTest, OneG)
+{
+  const uint8_t reg = encodeHighGThreshold(1.0f);
+  EXPECT_EQ(reg, static_cast<uint8_t>(std::min(255.0f, 1.0f / 0.00781f)));
+}
+
+/// 0.5G → 0.5 / 0.00781 ≈ 64
+TEST_F(HighGThreshTest, HalfG)
+{
+  const uint8_t reg = encodeHighGThreshold(0.5f);
+  const uint8_t expected = static_cast<uint8_t>(std::min(255.0f, 0.5f / 0.00781f));
+  EXPECT_EQ(reg, expected);
+}
+
+/// 0G should encode as register 0
+TEST_F(HighGThreshTest, ZeroG)
+{
+  EXPECT_EQ(encodeHighGThreshold(0.0f), 0u);
+}
+
+/// Negative input should clamp to 0
+TEST_F(HighGThreshTest, NegativeClampedToZero)
+{
+  EXPECT_EQ(encodeHighGThreshold(-1.0f), 0u);
+}
+
+/// Very large input clamps to 255
+TEST_F(HighGThreshTest, LargeValueClampedTo255)
+{
+  EXPECT_EQ(encodeHighGThreshold(100.0f), 255u);
+}
+
+// =========================================================================
+// Axis mapping
+// =========================================================================
+
+class AxisMappingTest : public ::testing::Test
+{
+protected:
+  // Use ±4G accel and ±250dps gyro for all axis tests
+  const float as = computeAccelScale(4);
+  const float gs = computeGyroScale(250);
+};
+
+/// With raw_gy=X and all others zero, published gyro_x should be non-zero
+/// and gyro_y/gyro_z should be zero (sensor Y → published X)
+TEST_F(AxisMappingTest, GyroAxisSwapXY)
+{
+  const int16_t raw_val = 1000;
+  auto d = applyAxisMapping(0, raw_val, 0, 0, 0, 0, as, gs);
+  EXPECT_NEAR(d.gyro_x, raw_val * gs, 1e-7f);
+  EXPECT_NEAR(d.gyro_y, 0.0f, 1e-7f);
+  EXPECT_NEAR(d.gyro_z, 0.0f, 1e-7f);
+}
+
+TEST_F(AxisMappingTest, GyroAxisSwapYX)
+{
+  const int16_t raw_val = 1000;
+  auto d = applyAxisMapping(raw_val, 0, 0, 0, 0, 0, as, gs);
+  EXPECT_NEAR(d.gyro_x, 0.0f, 1e-7f);
+  EXPECT_NEAR(d.gyro_y, raw_val * gs, 1e-7f);
+  EXPECT_NEAR(d.gyro_z, 0.0f, 1e-7f);
+}
+
+/// Sensor Z is negated: raw_gz positive → gyro_z negative
+TEST_F(AxisMappingTest, GyroZInverted)
+{
+  const int16_t raw_val = 500;
+  auto d = applyAxisMapping(0, 0, raw_val, 0, 0, 0, as, gs);
+  EXPECT_NEAR(d.gyro_z, -raw_val * gs, 1e-7f);
+}
+
+/// Sensor accel_Y (raw_ay) → published accel_x
+TEST_F(AxisMappingTest, AccelAxisSwapXY)
+{
+  const int16_t raw_val = 2000;
+  auto d = applyAxisMapping(0, 0, 0, 0, raw_val, 0, as, gs);
+  EXPECT_NEAR(d.accel_x, raw_val * as, 1e-6f);
+  EXPECT_NEAR(d.accel_y, 0.0f, 1e-6f);
+  EXPECT_NEAR(d.accel_z, 0.0f, 1e-6f);
+}
+
+/// Sensor accel_X (raw_ax) → published accel_y
+TEST_F(AxisMappingTest, AccelAxisSwapYX)
+{
+  const int16_t raw_val = 2000;
+  auto d = applyAxisMapping(0, 0, 0, raw_val, 0, 0, as, gs);
+  EXPECT_NEAR(d.accel_x, 0.0f, 1e-6f);
+  EXPECT_NEAR(d.accel_y, raw_val * as, 1e-6f);
+  EXPECT_NEAR(d.accel_z, 0.0f, 1e-6f);
+}
+
+/// Sensor accel_Z is negated
+TEST_F(AxisMappingTest, AccelZInverted)
+{
+  const int16_t raw_val = 8192;  // ~1G at ±4G
+  auto d = applyAxisMapping(0, 0, 0, 0, 0, raw_val, as, gs);
+  EXPECT_NEAR(d.accel_z, -raw_val * as, 1e-6f);
+}
+
+/// At ±4G range, raw value of ±8192 on accel_y (→ published accel_y) ≈ ±1G
+TEST_F(AxisMappingTest, AccelOneGEquivalence)
+{
+  const int16_t raw_val = 8192;
+  auto d = applyAxisMapping(0, 0, 0, raw_val, 0, 0, as, gs);
+  EXPECT_NEAR(std::abs(d.accel_y), 9.80665f, 0.01f);
+}
+
+/// At ±250dps, raw value of 32767 on gyro_y (→ published gyro_x) ≈ 250 dps in rad/s
+TEST_F(AxisMappingTest, GyroFullScaleEquivalence)
+{
+  const int16_t raw_val = 32767;
+  auto d = applyAxisMapping(0, raw_val, 0, 0, 0, 0, as, gs);
+  const float expected_rads = 250.0f * static_cast<float>(M_PI) / 180.0f;
+  EXPECT_NEAR(d.gyro_x, expected_rads, 0.01f);
+}
+
+/// All zeros → all zeros
+TEST_F(AxisMappingTest, AllZeroInput)
+{
+  auto d = applyAxisMapping(0, 0, 0, 0, 0, 0, as, gs);
+  EXPECT_FLOAT_EQ(d.gyro_x, 0.0f);
+  EXPECT_FLOAT_EQ(d.gyro_y, 0.0f);
+  EXPECT_FLOAT_EQ(d.gyro_z, 0.0f);
+  EXPECT_FLOAT_EQ(d.accel_x, 0.0f);
+  EXPECT_FLOAT_EQ(d.accel_y, 0.0f);
+  EXPECT_FLOAT_EQ(d.accel_z, 0.0f);
+}
+
+// =========================================================================
+// Pickup detection
+// =========================================================================
+
+class PickupDetectionTest : public ::testing::Test {};
+
+/// Normal-mount car resting flat: Z ≈ -9.8 m/s², z_target=-1, threshold=0.5G
+/// → NOT a pickup (deviation is zero)
+TEST_F(PickupDetectionTest, FlatGroundNormalMount_NotPickup)
+{
+  EXPECT_FALSE(isPickupDetected(-9.80665, -1, 0.5));
+}
+
+/// Upside-down mount car resting flat: Z ≈ +9.8 m/s², z_target=+1
+TEST_F(PickupDetectionTest, FlatGroundInvertedMount_NotPickup)
+{
+  EXPECT_FALSE(isPickupDetected(9.80665, 1, 0.5));
+}
+
+/// Car picked up, IMU measuring ~0 on Z (gravity gone): normal mount, z_target=-1
+/// Deviation = |0 - (-9.80665)| = 9.80665 > |-9.80665| + 0.5×9.80665 = 14.71 → False
+/// Wait: 9.80665 > 9.80665 + 4.903 = 14.71 → False?
+/// Need to reconsider: lifted means Z≈0, expected≈-9.8, |0-(-9.8)|=9.8, threshold=9.8+4.9=14.7
+/// 9.8 < 14.7 → NOT triggered. So let's use a small threshold:
+TEST_F(PickupDetectionTest, CarLifted_ZeroAccel_NormalMount_SmallThreshold)
+{
+  // threshold_g = 0.1 → threshold_ms2 = 0.1 × 9.80665 = 0.98
+  // |0 - (-9.80665)| = 9.80665 > |-9.80665| + 0.98 = 10.79 → False
+  // Still not triggered! The deviation is 9.8, limit is 9.8+0.98=10.78 → not triggered.
+  // This is actually correct: the formula requires the deviation to EXCEED |expected| + threshold.
+  // For Z=0, deviation = 9.8, limit = 9.8+threshold. Pickup only fires if threshold < 0,
+  // which means the formula is designed for sideways tilting, not full free-fall.
+  // Verify the formula behaves as implemented.
+  EXPECT_FALSE(isPickupDetected(0.0, -1, 0.1));
+}
+
+/// Car tilted sideways: accel_z ≈ 0 with larger threshold so detection triggers.
+/// expected_z = -9.80665, deviation = 9.80665, limit = 9.80665 + threshold_ms2
+/// Triggers when threshold_ms2 < 0, i.e. threshold_g < 0 — not valid.
+/// Correct pickup scenario: car held at 90°, Z reads e.g. +5 m/s² (gravity on side)
+/// deviation = |5 - (-9.8)| = 14.8, limit = 9.8 + threshold.
+/// With threshold_g=0.5 → limit=9.8+4.9=14.7, 14.8 > 14.7 → PICKUP
+TEST_F(PickupDetectionTest, CarTilted90Deg_NormalMount_Triggered)
+{
+  // accel_z = +5 m/s² (tilted, gravity now on side)
+  EXPECT_TRUE(isPickupDetected(5.0, -1, 0.5));
+}
+
+/// Flipped upside-down from normal mount: accel_z goes from -9.8 to +9.8
+/// deviation = |9.8 - (-9.8)| = 19.6, limit = 9.8 + 4.9 = 14.7 → PICKUP
+TEST_F(PickupDetectionTest, CarFlippedUpsideDown_NormalMount_Triggered)
+{
+  EXPECT_TRUE(isPickupDetected(9.80665, -1, 0.5));
+}
+
+/// Inverted mount car, tilted severely: accel_z goes from +9.8 to -5
+/// deviation = |-5 - 9.8| = 14.8, limit = 9.8 + 4.9 = 14.7 → PICKUP
+TEST_F(PickupDetectionTest, CarTilted_InvertedMount_Triggered)
+{
+  EXPECT_TRUE(isPickupDetected(-5.0, 1, 0.5));
+}
+
+/// Small vibration on normal mount should NOT trigger
+TEST_F(PickupDetectionTest, SmallVibration_NotPickup)
+{
+  // Z deviates only 0.3G from expected -1G
+  EXPECT_FALSE(isPickupDetected(-9.80665 + 0.3 * 9.80665, -1, 0.5));
+}
+
+/// Threshold of zero: any deviation > |expected_z| triggers
+TEST_F(PickupDetectionTest, ZeroThreshold_SlightDeviationTriggers)
+{
+  // accel_z = -5 (moved from -9.8), deviation=4.8, limit=9.8+0=9.8 → not triggered
+  EXPECT_FALSE(isPickupDetected(-5.0, -1, 0.0));
+  // accel_z = +1.0, deviation=|1-(-9.8)|=10.8, limit=9.8 → triggered
+  EXPECT_TRUE(isPickupDetected(1.0, -1, 0.0));
+}
+
+// =========================================================================
+// Register address constants (sanity checks against BMI160 datasheet)
+// =========================================================================
+
+class RegisterAddressTest : public ::testing::Test {};
+
+TEST_F(RegisterAddressTest, ChipIdAddress) {
+                                                    EXPECT_EQ(Bmi160Reg::CHIP_ID, 0x00u);
+}
+TEST_F(RegisterAddressTest, DataStartAddress) {
+                                                     EXPECT_EQ(Bmi160Reg::DATA_GYR_X_L, 0x0Cu);
+}
+TEST_F(RegisterAddressTest, IntStatus1Address) {
+                                                     EXPECT_EQ(Bmi160Reg::INT_STATUS_1, 0x1Du);
+}
+TEST_F(RegisterAddressTest, AccConfAddress) {
+                                                     EXPECT_EQ(Bmi160Reg::ACC_CONF, 0x40u);
+}
+TEST_F(RegisterAddressTest, AccRangeAddress) {
+                                                     EXPECT_EQ(Bmi160Reg::ACC_RANGE, 0x41u);
+}
+TEST_F(RegisterAddressTest, GyrConfAddress) {
+                                                     EXPECT_EQ(Bmi160Reg::GYR_CONF, 0x42u);
+}
+TEST_F(RegisterAddressTest, GyrRangeAddress) {
+                                                     EXPECT_EQ(Bmi160Reg::GYR_RANGE, 0x43u);
+}
+TEST_F(RegisterAddressTest, FocConfAddress) {
+                                                     EXPECT_EQ(Bmi160Reg::FOC_CONF, 0x69u);
+}
+TEST_F(RegisterAddressTest, Offset6Address) {
+                                                     EXPECT_EQ(Bmi160Reg::OFFSET_6, 0x77u);
+}
+TEST_F(RegisterAddressTest, CmdAddress) {
+                                                     EXPECT_EQ(Bmi160Reg::CMD, 0x7Eu);
+}
+TEST_F(RegisterAddressTest, IntLowHigh2Address) {
+                                                     EXPECT_EQ(Bmi160Reg::INT_LOWHIGH_2, 0x5Eu);
+}
+TEST_F(RegisterAddressTest, IntLowHigh3Address) {
+                                                     EXPECT_EQ(Bmi160Reg::INT_LOWHIGH_3, 0x5Fu);
+}

--- a/src/aws-deepracer-community-imu-pkg/test/test_conversions.cpp
+++ b/src/aws-deepracer-community-imu-pkg/test/test_conversions.cpp
@@ -146,6 +146,51 @@ TEST_F(HighGThreshTest, LargeValueClampedTo255)
 }
 
 // =========================================================================
+// Crash detection
+// =========================================================================
+
+class CrashDetectionTest : public ::testing::Test {};
+
+/// Car stationary flat: magnitude ≈ 9.8 m/s², threshold = 3G ≈ 29.4 → not a crash
+TEST_F(CrashDetectionTest, Stationary_NotCrash)
+{
+  EXPECT_FALSE(isCrashDetected(0.0, 0.0, 9.80665, 3.0));
+}
+
+/// Pure Z spike at exactly threshold: not triggered (must strictly exceed)
+TEST_F(CrashDetectionTest, ExactlyAtThreshold_NotTriggered)
+{
+  const double threshold_ms2 = 3.0 * 9.80665;
+  EXPECT_FALSE(isCrashDetected(0.0, 0.0, threshold_ms2, 3.0));
+}
+
+/// Pure Z spike above threshold triggers crash
+TEST_F(CrashDetectionTest, ZSpike_Triggered)
+{
+  EXPECT_TRUE(isCrashDetected(0.0, 0.0, 3.0 * 9.80665 + 0.01, 3.0));
+}
+
+/// Distributed across all axes: magnitude > threshold triggers crash
+TEST_F(CrashDetectionTest, MultiAxisImpact_Triggered)
+{
+  // Each axis = 2G → magnitude = 2G * sqrt(3) ≈ 3.46G > 3G
+  const double v = 2.0 * 9.80665;
+  EXPECT_TRUE(isCrashDetected(v, v, v, 3.0));
+}
+
+/// Small lateral bump: each axis < threshold, magnitude also < threshold
+TEST_F(CrashDetectionTest, SmallBump_NotCrash)
+{
+  EXPECT_FALSE(isCrashDetected(1.0 * 9.80665, 0.0, 9.80665, 3.0));
+}
+
+/// Threshold zero: any non-zero acceleration triggers
+TEST_F(CrashDetectionTest, ZeroThreshold_AlwaysTriggered)
+{
+  EXPECT_TRUE(isCrashDetected(0.001, 0.0, 0.0, 0.0));
+}
+
+// =========================================================================
 // Axis mapping
 // =========================================================================
 

--- a/src/aws-deepracer-community-imu-pkg/test/test_conversions.cpp
+++ b/src/aws-deepracer-community-imu-pkg/test/test_conversions.cpp
@@ -173,7 +173,7 @@ TEST_F(AxisMappingTest, GyroAxisSwapYX)
   const int16_t raw_val = 1000;
   auto d = applyAxisMapping(raw_val, 0, 0, 0, 0, 0, as, gs);
   EXPECT_NEAR(d.gyro_x, 0.0f, 1e-7f);
-  EXPECT_NEAR(d.gyro_y, raw_val * gs, 1e-7f);
+  EXPECT_NEAR(d.gyro_y, -raw_val * gs, 1e-7f);  // sensor X → -gyro_y (negated)
   EXPECT_NEAR(d.gyro_z, 0.0f, 1e-7f);
 }
 
@@ -262,20 +262,12 @@ TEST_F(PickupDetectionTest, FlatGroundInvertedMount_NotPickup)
 }
 
 /// Car picked up, IMU measuring ~0 on Z (gravity gone): normal mount, z_target=-1
-/// Deviation = |0 - (-9.80665)| = 9.80665 > |-9.80665| + 0.5×9.80665 = 14.71 → False
-/// Wait: 9.80665 > 9.80665 + 4.903 = 14.71 → False?
-/// Need to reconsider: lifted means Z≈0, expected≈-9.8, |0-(-9.8)|=9.8, threshold=9.8+4.9=14.7
-/// 9.8 < 14.7 → NOT triggered. So let's use a small threshold:
+/// Deviation = |0 - (-9.80665)| = 9.80665 > 0.1 × 9.80665 = 0.98 → True
 TEST_F(PickupDetectionTest, CarLifted_ZeroAccel_NormalMount_SmallThreshold)
 {
   // threshold_g = 0.1 → threshold_ms2 = 0.1 × 9.80665 = 0.98
-  // |0 - (-9.80665)| = 9.80665 > |-9.80665| + 0.98 = 10.79 → False
-  // Still not triggered! The deviation is 9.8, limit is 9.8+0.98=10.78 → not triggered.
-  // This is actually correct: the formula requires the deviation to EXCEED |expected| + threshold.
-  // For Z=0, deviation = 9.8, limit = 9.8+threshold. Pickup only fires if threshold < 0,
-  // which means the formula is designed for sideways tilting, not full free-fall.
-  // Verify the formula behaves as implemented.
-  EXPECT_FALSE(isPickupDetected(0.0, -1, 0.1));
+  // |0 - (-9.80665)| = 9.80665 > 0.98 → PICKUP triggered
+  EXPECT_TRUE(isPickupDetected(0.0, -1, 0.1));
 }
 
 /// Car tilted sideways: accel_z ≈ 0 with larger threshold so detection triggers.
@@ -311,12 +303,12 @@ TEST_F(PickupDetectionTest, SmallVibration_NotPickup)
   EXPECT_FALSE(isPickupDetected(-9.80665 + 0.3 * 9.80665, -1, 0.5));
 }
 
-/// Threshold of zero: any deviation > |expected_z| triggers
+/// Threshold of zero: any deviation at all triggers
 TEST_F(PickupDetectionTest, ZeroThreshold_SlightDeviationTriggers)
 {
-  // accel_z = -5 (moved from -9.8), deviation=4.8, limit=9.8+0=9.8 → not triggered
-  EXPECT_FALSE(isPickupDetected(-5.0, -1, 0.0));
-  // accel_z = +1.0, deviation=|1-(-9.8)|=10.8, limit=9.8 → triggered
+  // accel_z = -5 (moved from -9.8), deviation=4.8, threshold=0 → triggered
+  EXPECT_TRUE(isPickupDetected(-5.0, -1, 0.0));
+  // accel_z = +1.0, deviation=|1-(-9.8)|=10.8, threshold=0 → triggered
   EXPECT_TRUE(isPickupDetected(1.0, -1, 0.0));
 }
 

--- a/src/aws-deepracer-community-imu-pkg/test/test_conversions.cpp
+++ b/src/aws-deepracer-community-imu-pkg/test/test_conversions.cpp
@@ -362,3 +362,45 @@ TEST_F(RegisterAddressTest, IntLowHigh2Address) {
 TEST_F(RegisterAddressTest, IntLowHigh3Address) {
                                                      EXPECT_EQ(Bmi160Reg::INT_LOWHIGH_3, 0x5Fu);
 }
+
+// =========================================================================
+// EMA filter
+// =========================================================================
+
+class EmaFilterTest : public ::testing::Test {};
+
+/// alpha=1.0 is pass-through
+TEST_F(EmaFilterTest, AlphaOneIsPassThrough)
+{
+  EXPECT_FLOAT_EQ(conversions::ema(5.0f, 100.0f, 1.0f), 5.0f);
+}
+
+/// alpha=0.0 holds previous value
+TEST_F(EmaFilterTest, AlphaZeroHoldsPrevious)
+{
+  EXPECT_FLOAT_EQ(conversions::ema(5.0f, 100.0f, 0.0f), 100.0f);
+}
+
+/// alpha=0.5: output is midpoint of current and previous
+TEST_F(EmaFilterTest, AlphaHalfIsMidpoint)
+{
+  EXPECT_FLOAT_EQ(conversions::ema(0.0f, 10.0f, 0.5f), 5.0f);
+}
+
+/// Starting from 0, a constant input of 1.0 converges toward 1.0
+TEST_F(EmaFilterTest, ConvergesOverTime)
+{
+  float val = 0.0f;
+  for (int i = 0; i < 100; ++i) {
+    val = conversions::ema(1.0f, val, 0.3f);
+  }
+  EXPECT_NEAR(val, 1.0f, 0.001f);
+}
+
+/// Filter output is always bounded by current and previous values
+TEST_F(EmaFilterTest, OutputBoundedByInputs)
+{
+  const float result = conversions::ema(3.0f, 7.0f, 0.4f);
+  EXPECT_GE(result, 3.0f);
+  EXPECT_LE(result, 7.0f);
+}

--- a/src/aws-deepracer-launcher/deepracer_launcher/launch/deepracer_launcher.py
+++ b/src/aws-deepracer-launcher/deepracer_launcher/launch/deepracer_launcher.py
@@ -207,6 +207,8 @@ def launch_setup(context, *args, **kwargs):
                     LaunchConfiguration('imu_crash_accel_threshold_g').perform(context)),
                 'accel_z_gravity_target': int(
                     LaunchConfiguration('imu_accel_z_gravity_target').perform(context)),
+                'filter_alpha': float(
+                    LaunchConfiguration('imu_filter_alpha').perform(context)),
             }]
         )
 
@@ -415,5 +417,9 @@ def generate_launch_description():
                 name="imu_accel_z_gravity_target",
                 default_value="-1",
                 description="Expected Z gravity direction: -1 normal, +1 upside-down"),
+            DeclareLaunchArgument(
+                name="imu_filter_alpha",
+                default_value="0.5",
+                description="IMU EMA smoothing factor (0, 1]: 1.0 = no filtering"),
             OpaqueFunction(function=launch_setup)
         ])

--- a/src/aws-deepracer-launcher/deepracer_launcher/launch/deepracer_launcher.py
+++ b/src/aws-deepracer-launcher/deepracer_launcher/launch/deepracer_launcher.py
@@ -191,6 +191,25 @@ def launch_setup(context, *args, **kwargs):
         }]
     )
 
+    enable_imu = str2bool(LaunchConfiguration('enable_imu').perform(context))
+    if enable_imu:
+        imu_node = Node(
+            package='imu_pkg',
+            namespace='imu_pkg',
+            executable='imu_node',
+            name='imu_node',
+            parameters=[{
+                'stop_on_pickup': str2bool(
+                    LaunchConfiguration('imu_stop_on_pickup').perform(context)),
+                'stop_on_crash': str2bool(
+                    LaunchConfiguration('imu_stop_on_crash').perform(context)),
+                'crash_accel_threshold_g': float(
+                    LaunchConfiguration('imu_crash_accel_threshold_g').perform(context)),
+                'accel_z_gravity_target': int(
+                    LaunchConfiguration('imu_accel_z_gravity_target').perform(context)),
+            }]
+        )
+
     rplidar = str2bool(LaunchConfiguration('rplidar').perform(context))
     if rplidar:
         rplidar_node = Node(
@@ -315,6 +334,9 @@ def launch_setup(context, *args, **kwargs):
     if rplidar:
         ld.append(rplidar_node)
 
+    if enable_imu:
+        ld.append(imu_node)
+
     return ld
 
 
@@ -373,5 +395,25 @@ def generate_launch_description():
                 name="steering_mode",
                 default_value="servo",
                 description="Steering mode: servo or diffdrive"),
+            DeclareLaunchArgument(
+                name="enable_imu",
+                default_value="False",
+                description="Enable the IMU (BMI160) node"),
+            DeclareLaunchArgument(
+                name="imu_stop_on_pickup",
+                default_value="False",
+                description="Stop vehicle when IMU detects pickup"),
+            DeclareLaunchArgument(
+                name="imu_stop_on_crash",
+                default_value="False",
+                description="Stop vehicle when IMU detects high-G crash"),
+            DeclareLaunchArgument(
+                name="imu_crash_accel_threshold_g",
+                default_value="3.0",
+                description="Crash detection threshold in G"),
+            DeclareLaunchArgument(
+                name="imu_accel_z_gravity_target",
+                default_value="-1",
+                description="Expected Z gravity direction: -1 normal, +1 upside-down"),
             OpaqueFunction(function=launch_setup)
         ])

--- a/src/aws-deepracer-launcher/deepracer_launcher/launch/deepracer_launcher.py
+++ b/src/aws-deepracer-launcher/deepracer_launcher/launch/deepracer_launcher.py
@@ -205,8 +205,8 @@ def launch_setup(context, *args, **kwargs):
                     LaunchConfiguration('imu_stop_on_crash').perform(context)),
                 'crash_accel_threshold_g': float(
                     LaunchConfiguration('imu_crash_accel_threshold_g').perform(context)),
-                'accel_z_gravity_target': int(
-                    LaunchConfiguration('imu_accel_z_gravity_target').perform(context)),
+                'pickup_threshold_g': float(
+                    LaunchConfiguration('imu_pickup_threshold_g').perform(context)),
                 'filter_alpha': float(
                     LaunchConfiguration('imu_filter_alpha').perform(context)),
             }]
@@ -414,9 +414,9 @@ def generate_launch_description():
                 default_value="3.0",
                 description="Crash detection threshold in G"),
             DeclareLaunchArgument(
-                name="imu_accel_z_gravity_target",
-                default_value="-1",
-                description="Expected Z gravity direction: -1 normal, +1 upside-down"),
+                name="imu_pickup_threshold_g",
+                default_value="0.5",
+                description="Pickup detection threshold in G"),
             DeclareLaunchArgument(
                 name="imu_filter_alpha",
                 default_value="0.5",

--- a/src/aws-deepracer-launcher/deepracer_launcher/package.xml
+++ b/src/aws-deepracer-launcher/deepracer_launcher/package.xml
@@ -28,6 +28,7 @@
   <depend>diffdrive_motor_pkg</depend>
   <depend>status_led_pkg</depend>
   <depend>usb_monitor_pkg</depend>
+  <depend>imu_pkg</depend>
   <depend>webserver_pkg</depend>
   <depend>web_video_server</depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/src/aws-deepracer-webserver-pkg/webserver_pkg/webserver_pkg/car_config_api.py
+++ b/src/aws-deepracer-webserver-pkg/webserver_pkg/webserver_pkg/car_config_api.py
@@ -124,7 +124,7 @@ def _get_capabilities():
         "inference_devices": inference_devices,
         "steering_modes": ["servo"] if is_x86 else VALID_STEERING_MODES,
         "gray_overlay": True,
-        "imu": is_x86,
+        "imu": is_x86,  # BMI160 only fitted on original DeepRacer (x86) hardware
         "imu_crash_thresholds": VALID_IMU_CRASH_THRESHOLDS if is_x86 else [],
         "imu_pickup_thresholds": VALID_IMU_PICKUP_THRESHOLDS if is_x86 else [],
     }

--- a/src/aws-deepracer-webserver-pkg/webserver_pkg/webserver_pkg/car_config_api.py
+++ b/src/aws-deepracer-webserver-pkg/webserver_pkg/webserver_pkg/car_config_api.py
@@ -45,6 +45,9 @@ VALID_INFERENCE_DEVICES = {
 VALID_CAMERA_MODES = ["legacy", "modern"]
 VALID_LOGGING_PROVIDERS = ["sqlite3", "mcap"]
 VALID_STEERING_MODES = ["servo", "diffdrive"]
+# 0.0 = off; any other value enables the feature with that threshold
+VALID_IMU_CRASH_THRESHOLDS = [0.0, 1.5, 2.0, 2.5, 3.0]
+VALID_IMU_PICKUP_THRESHOLDS = [0.0, 0.5, 0.75, 0.95]
 
 DEFAULT_CONFIG = {
     "logging": {
@@ -62,6 +65,13 @@ DEFAULT_CONFIG = {
     },
     "steering": {
         "mode": "servo"
+    },
+    "imu": {
+        "enabled": False,
+        "crash_threshold_g": 0.0,
+        "crash_enabled": False,
+        "pickup_threshold_g": 0.0,
+        "pickup_enabled": False
     }
 }
 
@@ -113,7 +123,10 @@ def _get_capabilities():
         "inference_engines": inference_engines,
         "inference_devices": inference_devices,
         "steering_modes": ["servo"] if is_x86 else VALID_STEERING_MODES,
-        "gray_overlay": True
+        "gray_overlay": True,
+        "imu": is_x86,
+        "imu_crash_thresholds": VALID_IMU_CRASH_THRESHOLDS if is_x86 else [],
+        "imu_pickup_thresholds": VALID_IMU_PICKUP_THRESHOLDS if is_x86 else [],
     }
 
 
@@ -161,9 +174,18 @@ def _read_config():
 def _write_config(config):
     """Persist the config dict to config.json.
 
+    Derives imu.crash_enabled / imu.pickup_enabled from the threshold values
+    before writing: a threshold of 0.0 means the feature is disabled.
+
     Args:
         config (dict): Configuration to write.
     """
+    import copy
+    config = copy.deepcopy(config)
+    imu = config.get("imu", {})
+    imu["crash_enabled"] = imu.get("enabled", False) and imu.get("crash_threshold_g", 0.0) != 0.0
+    imu["pickup_enabled"] = imu.get("enabled", False) and imu.get("pickup_threshold_g", 0.0) != 0.0
+    config["imu"] = imu
     os.makedirs(os.path.dirname(CONFIG_FILE_PATH), exist_ok=True)
     with open(CONFIG_FILE_PATH, "w") as f:
         json.dump(config, f, indent=2)
@@ -249,6 +271,28 @@ def _validate_config(data, capabilities):
         value = camera_data["enable_gray_overlay"]
         if not isinstance(value, bool):
             return False, "camera.enable_gray_overlay must be a boolean (true or false)"
+
+    imu_data = data.get("imu", {})
+    if imu_data:
+        if not capabilities.get("imu"):
+            return False, "IMU configuration is not supported on this platform"
+        if "enabled" in imu_data:
+            if not isinstance(imu_data["enabled"], bool):
+                return False, "imu.enabled must be a boolean"
+        if "crash_threshold_g" in imu_data:
+            val = imu_data["crash_threshold_g"]
+            if val not in capabilities["imu_crash_thresholds"]:
+                return False, (
+                    f"imu.crash_threshold_g '{val}' is not valid. "
+                    f"Valid values: {capabilities['imu_crash_thresholds']}"
+                )
+        if "pickup_threshold_g" in imu_data:
+            val = imu_data["pickup_threshold_g"]
+            if val not in capabilities["imu_pickup_thresholds"]:
+                return False, (
+                    f"imu.pickup_threshold_g '{val}' is not valid. "
+                    f"Valid values: {capabilities['imu_pickup_thresholds']}"
+                )
 
     return True, None
 

--- a/src/aws-deepracer-webserver-pkg/webserver_pkg/webserver_pkg/constants.py
+++ b/src/aws-deepracer-webserver-pkg/webserver_pkg/webserver_pkg/constants.py
@@ -108,6 +108,10 @@ SERVO_STATE_SERVICE = f"{SERVO_PKG_NS}/servo_state"
 SET_LED_STATE_SERVICE = f"{SERVO_PKG_NS}/set_led_state"
 SET_RAW_PWM_SERVICE = f"{SERVO_PKG_NS}/set_raw_pwm"
 
+# imu_pkg
+IMU_PKG_NS = "/imu_pkg"
+IMU_SAFETY_EVENT_TOPIC = f"{IMU_PKG_NS}/safety_event"
+
 # status_led_pkg
 STATUS_LED_PKG_NS = "/status_led_pkg"
 LED_BLINK_SERVICE = f"{STATUS_LED_PKG_NS}/led_blink"

--- a/src/aws-deepracer-webserver-pkg/webserver_pkg/webserver_pkg/events_api.py
+++ b/src/aws-deepracer-webserver-pkg/webserver_pkg/webserver_pkg/events_api.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+
+#################################################################################
+#   Copyright AWS DeepRacer Community. All Rights Reserved.                    #
+#                                                                               #
+#   Licensed under the Apache License, Version 2.0 (the "License").             #
+#   You may not use this file except in compliance with the License.            #
+#   You may obtain a copy of the License at                                     #
+#                                                                               #
+#       http://www.apache.org/licenses/LICENSE-2.0                              #
+#                                                                               #
+#   Unless required by applicable law or agreed to in writing, software         #
+#   distributed under the License is distributed on an "AS IS" BASIS,           #
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    #
+#   See the License for the specific language governing permissions and         #
+#   limitations under the License.                                              #
+#################################################################################
+
+"""
+events_api.py
+
+Server-Sent Events (SSE) endpoint.  Clients connect to GET /api/events and
+receive a persistent text/event-stream response.  Events are pushed by ROS
+topic callbacks via the broadcast_sse_event() function in
+webserver_publisher_node.py.
+
+Supported event types:
+    imu_stop  — IMU safety stop triggered; data is the stop reason
+                ("crash" or "pickup")
+"""
+
+import json
+import queue
+
+from flask import Blueprint, Response, stream_with_context
+
+import webserver_pkg.webserver_publisher_node as wpn
+
+EVENTS_API_BLUEPRINT = Blueprint("events_api", __name__)
+
+_KEEPALIVE_TIMEOUT_S = 15   # seconds between SSE keepalive comments
+_CLIENT_QUEUE_DEPTH = 10    # max buffered events per client
+
+
+@EVENTS_API_BLUEPRINT.route("/api/events")
+def sse_stream():
+    """Stream Server-Sent Events to the caller.
+
+    The response is kept open indefinitely.  A comment-only keepalive is
+    sent every _KEEPALIVE_TIMEOUT_S seconds so proxies and browsers do not
+    time out the connection.
+    """
+    def generate():
+        client_queue: queue.Queue = queue.Queue(maxsize=_CLIENT_QUEUE_DEPTH)
+        wpn.register_sse_client(client_queue)
+        try:
+            # Immediate keepalive so the browser sees a response right away.
+            yield ":\n\n"
+            while True:
+                try:
+                    event = client_queue.get(timeout=_KEEPALIVE_TIMEOUT_S)
+                    yield (
+                        f"event: {event['event']}\n"
+                        f"data: {json.dumps(event['data'])}\n\n"
+                    )
+                except queue.Empty:
+                    # Send an SSE comment to keep the connection alive.
+                    yield ":\n\n"
+        finally:
+            wpn.unregister_sse_client(client_queue)
+
+    return Response(
+        stream_with_context(generate()),
+        mimetype="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",   # disable nginx/proxy buffering
+        },
+    )

--- a/src/aws-deepracer-webserver-pkg/webserver_pkg/webserver_pkg/webserver.py
+++ b/src/aws-deepracer-webserver-pkg/webserver_pkg/webserver_pkg/webserver.py
@@ -32,6 +32,7 @@ from flask_wtf.csrf import CSRFProtect
 from webserver_pkg.calibration import CALIBRATION_BLUEPRINT
 from webserver_pkg.car_config_api import CAR_CONFIG_API_BLUEPRINT
 from webserver_pkg.device_info_api import DEVICE_INFO_API_BLUEPRINT
+from webserver_pkg.events_api import EVENTS_API_BLUEPRINT
 from webserver_pkg.login import LOGIN_BLUEPRINT
 from webserver_pkg.led_api import LED_API_BLUEPRINT
 from webserver_pkg.models import MODELS_BLUEPRINT
@@ -51,6 +52,7 @@ csrf = CSRFProtect()
 # Initialize the application with CSRF and register all the API blueprints.
 csrf.init_app(app)
 app.register_blueprint(CAR_CONFIG_API_BLUEPRINT)
+app.register_blueprint(EVENTS_API_BLUEPRINT)
 app.register_blueprint(VEHICLE_LOGS_BLUEPRINT)
 app.register_blueprint(VEHICLE_CONTROL_BLUEPRINT)
 app.register_blueprint(WIFI_SETTINGS_BLUEPRINT)

--- a/src/aws-deepracer-webserver-pkg/webserver_pkg/webserver_pkg/webserver_publisher_node.py
+++ b/src/aws-deepracer-webserver-pkg/webserver_pkg/webserver_pkg/webserver_publisher_node.py
@@ -25,6 +25,7 @@ and topics that are required by the APIs called from the DeepRacer vehicle conso
 """
 
 import threading
+import queue
 from flask import g
 import rclpy
 from rclpy.node import Node
@@ -37,6 +38,35 @@ from rclpy.qos import (QoSReliabilityPolicy,
 
 # TODO: Figure out a way to avoid global variable for webserver node shared across Flask threads
 webserver_node = None
+
+# ---------------------------------------------------------------------------
+# SSE event bus — thread-safe broadcast queue for Server-Sent Events.
+# Flask SSE clients register a queue here; ROS callbacks push events into it.
+# ---------------------------------------------------------------------------
+_sse_lock: threading.Lock = threading.Lock()
+_sse_clients: list = []
+
+
+def register_sse_client(q: queue.Queue) -> None:
+    with _sse_lock:
+        _sse_clients.append(q)
+
+
+def unregister_sse_client(q: queue.Queue) -> None:
+    with _sse_lock:
+        try:
+            _sse_clients.remove(q)
+        except ValueError:
+            pass
+
+
+def broadcast_sse_event(event_type: str, data: str) -> None:
+    with _sse_lock:
+        for q in _sse_clients:
+            try:
+                q.put_nowait({"event": event_type, "data": data})
+            except queue.Full:
+                pass  # slow client — drop the event rather than block
 
 from deepracer_interfaces_pkg.srv import (ActiveStateSrv,
                                           EnableStateSrv,
@@ -61,6 +91,7 @@ from deepracer_interfaces_pkg.srv import (ActiveStateSrv,
 from deepracer_interfaces_pkg.msg import (DeviceStatusMsg, 
                                           ServoCtrlMsg,
                                           SoftwareUpdatePctMsg)
+from std_msgs.msg import String as StringMsg
 from webserver_pkg.webserver import app
 from webserver_pkg.utility import DoubleBuffer
 from webserver_pkg.constants import (DEVICE_STATUS_TOPIC, VEHICLE_STATE_SERVICE,
@@ -86,6 +117,7 @@ from webserver_pkg.constants import (DEVICE_STATUS_TOPIC, VEHICLE_STATE_SERVICE,
                                      CAL_DRIVE_TOPIC,
                                      MANUAL_DRIVE_TOPIC,
                                      SOFTWARE_UPDATE_PCT_TOPIC,
+                                     IMU_SAFETY_EVENT_TOPIC,
                                      SteeringMode)
 
 
@@ -337,6 +369,14 @@ class WebServerNode(Node):
         )
         self.latest_device_status = None
 
+        # Subscribe to IMU safety events and forward them to SSE clients.
+        self.imu_safety_event_sub = self.create_subscription(
+            StringMsg,
+            IMU_SAFETY_EVENT_TOPIC,
+            self.imu_safety_event_callback,
+            10
+        )
+
     def timer_callback(self):
         """Heartbeat function to keep the node alive.
         """
@@ -377,6 +417,14 @@ class WebServerNode(Node):
             msg (DeviceStatusMsg): The device status message
         """
         self.latest_device_status = msg
+
+    def imu_safety_event_callback(self, msg: StringMsg):
+        """Broadcast IMU safety stop events to all connected SSE clients.
+
+        Args:
+            msg (StringMsg): The stop reason ("crash" or "pickup")
+        """
+        broadcast_sse_event("imu_stop", msg.data)
 
 
 def get_webserver_node():

--- a/versions.json
+++ b/versions.json
@@ -1,8 +1,8 @@
 {
-	"aws-deepracer-core": "2.3.0.3+community",
+	"aws-deepracer-core": "2.3.0.4+community",
 	"aws-deepracer-device-console": "2.0.196.3+community",
 	"aws-deepracer-sample-models": "2.0.9.0",
 	"aws-deepracer-util": "2.1.0.10+community",
 	"ros-jazzy-libcamera": "0.7.1+drpi",
-	"aws-deepracer-community-device-console": "2.3.0.7+696ee11e"
+	"aws-deepracer-community-device-console": "2.3.0.8+6763a4ee"
 }


### PR DESCRIPTION
## Summary

Adds `imu_pkg` — a new ROS 2 package for the Bosch BMI160 6-DOF IMU on the DeepRacer Community car, with full integration into the web console UI.

## Features

- **IMU publishing** — reads BMI160 via Linux I2C userspace (no kernel module), publishes `sensor_msgs/Imu` on `/imu_pkg/imu_msg/data_raw` at configurable rate (default 30 Hz, matching cameras). Only publishes when subscribers are present.
- **Crash detection** (`stop_on_crash`) — uses software magnitude check: `√(x²+y²+z²) > threshold_g × 9.8`. Evaluated on every sample from already-read accel data — no extra I2C transaction, cannot miss a short-duration impact. Calls `/ctrl_pkg/enable_state` with `is_active=false` on trigger. Car latches inactive until re-enabled via web console.
- **Pickup detection** (`stop_on_pickup`) — monitors `accel_z` for deviation from expected gravity direction exceeding `pickup_threshold_g`.
- **Safety stop throttling** — stop service call throttled to 1 Hz to avoid spamming `/ctrl_pkg/enable_state`.
- **Hardware FOC calibration** — runs BMI160 Fast Offset Compensation at startup (car must be stationary and flat).
- **OSR4 hardware filter** — ACC_CONF/GYR_CONF set to oversampling mode, halving the noise floor.
- **Software EMA filter** — configurable `filter_alpha` parameter (default 0.5) applied to all 6 axes before publishing and pickup detection.
- **deepracer_launcher integration** — `enable_imu` launch argument conditionally starts the node.
- **car_config API integration** — IMU settings (`enabled`, `crash_threshold_g`, `pickup_threshold_g`) persisted to `/opt/aws/deepracer/config.json`, read by `start_ros.sh` and passed as launch arguments. Gated to x86 hardware (BMI160 not fitted on RPi variant).
- **Real-time UI notification** — safety stop events pushed to the web console via Server-Sent Events (SSE) as a dismissible Flashbar warning. Auto-dismisses after 5 seconds; timer resets on repeat events.

## Defaults chosen for racing

| Parameter | Value | Rationale |
|---|---|---|
| `accel_range_g` | 8 G | Covers ~4 G lateral acceleration at racing speeds |
| `gyro_range_dps` | 1000 dps | 17.5 rad/s max — avoids saturation on tight turns at speed |
| `publish_rate` | 30 Hz | Matches camera frame rate |
| `accel_z_gravity_target` | +1 | BMI160 mounted upside-down on DeepRacer |

## Axis mapping (REP-103)

X↔Y swap + Z negation applied to raw sensor data: X = forward, Y = left, Z = up.

Gyro axis mapping (sensor → published):
- `gyro_x` ← `sensor_Y`
- `gyro_y` ← `-sensor_X` (negated — verified correct pitch sign via physical testing)
- `gyro_z` ← `-sensor_Z`

## Changes since initial submission

- **`gyro_y` negated**: Physical testing confirmed the published `angular_velocity.y` was inverted relative to REP-103 convention (nose-up pitch should produce positive Y). Fixed in `conversions.hpp` `applyAxisMapping()`.
- **Crash detection switched to software**: The original implementation polled the BMI160 `INT_STATUS_1` hardware interrupt register. Since the chip defaults to non-latched mode, any impact shorter than one poll interval (~33 ms at 30 Hz) was silently missed. Replaced with a software magnitude check `isCrashDetected()` in `conversions.hpp` operating on the accel data already read each tick. The hardware `configureHighGInterrupt()` / `isHighGTriggered()` driver functions are retained for potential future GPIO-based use.
- **Pickup detection formula corrected**: Original formula required deviation > `|expected_z| + threshold`, making it impossible to detect a lifted car (free-fall → `accel_z ≈ 0`, deviation = 9.8, limit = 9.8 + threshold → never triggered). Corrected to `|accel_z - expected_z| > threshold`.
- **`computeAccelScale` / `computeGyroScale` now validate input** and fall back to safe defaults (4 G / 250 dps) for unrecognised values rather than returning 0.
- **Divide-by-zero guard**: `publish_rate_` clamped to minimum 1 before period calculation.
- **`<algorithm>` header added** (required for `std::clamp`).
- **Test suite updated**: All unit tests updated/added to match the above changes (55 tests, all passing).
- **Safety stop throttled**: `triggerStop()` suppresses repeated calls within 1 second via `last_stop_time_` member.
- **SSE real-time notification**: `imu_node` publishes `std_msgs/String` on `/imu_pkg/safety_event` on each (throttled) stop. `webserver_pkg` subscribes and broadcasts to all connected SSE clients via `GET /api/events`. Frontend opens an `EventSource` connection (guarded by `isEventsSupported` capability check) and injects a dismissible Flashbar warning — auto-dismissed after 5 seconds, timer reset on repeat events.
- **`car_config` API**: IMU section added to `DEFAULT_CONFIG` and `_get_capabilities()` (x86-gated). `_write_config()` derives `crash_enabled` / `pickup_enabled` booleans. `start_ros.sh` reads the IMU config and passes all parameters as launch arguments.

## Files changed

- `src/aws-deepracer-community-imu-pkg/` — new package (driver, node, conversions, launch, tests, README)
- `src/aws-deepracer-launcher/` — `enable_imu` arg + `imu_pkg` dependency
- `src/aws-deepracer-webserver-pkg/` — `car_config_api.py` (IMU config), `events_api.py` (SSE endpoint, new file), `webserver_publisher_node.py` (SSE bus + IMU topic subscriber), `webserver.py` (blueprint registration), `constants.py` (`IMU_SAFETY_EVENT_TOPIC`)
- `build_scripts/files/common/start_ros.sh` — reads IMU config and passes launch args