### PR TITLE
Fix RPLIDAR launch failure on Jazzy (rplidar_composition)

### DIFF
--- a/src/aws-deepracer-launcher/deepracer_launcher/launch/deepracer_launcher.py
+++ b/src/aws-deepracer-launcher/deepracer_launcher/launch/deepracer_launcher.py
@@ -191,10 +191,13 @@ def launch_setup(context, *args, **kwargs):
 
     rplidar = str2bool(LaunchConfiguration('rplidar').perform(context))
     if rplidar:
+        # rplidar_ros 2.x ships the standalone executable as 'rplidar_composition';
+        # the Foxy-era package still provides it as 'rplidar_node'.
+        rplidar_executable = 'rplidar_node' if os.environ.get('ROS_DISTRO') == 'foxy' else 'rplidar_composition'
         rplidar_node = Node(
             package='rplidar_ros',
             namespace='rplidar_ros',
-            executable='rplidar_node',
+            executable=rplidar_executable,
             name='rplidar_node',
             parameters=[{
                     'serial_port': '/dev/ttyUSB0',


### PR DESCRIPTION
Fixes #76

## Problem

`rplidar_ros` 2.x renamed the standalone executable to `rplidar_composition`, but the launcher still requests `rplidar_node`. On Jazzy the launch aborts:

```
[ERROR] [launch]: Caught exception in launch (see debug for traceback):
executable 'rplidar_node' not found on the libexec directory '/opt/ros/jazzy/lib/rplidar_ros'
```

The exception propagates out of `launch_setup`, so the **whole** launch description fails and `deepracer-core` crash-loops. Attaching an RPLIDAR therefore takes down cameras, console and inference too, on a car that booted fine beforehand — and nothing in the symptoms points at the LiDAR.

`ros-jazzy-rplidar-ros` is installed and healthy; only the name differs:

```console
$ ls /opt/ros/jazzy/lib/rplidar_ros/
rplidar_composition
```

## Change

Select the executable by ROS distro so Foxy, which still ships `rplidar_node`, keeps working. This mirrors the existing `bag_log_executable` selection a few lines below in the same function.

The node `name` stays `rplidar_node`, so node and topic names are unchanged.

## Verification

On Ubuntu 24.04 / Jazzy with `ros-jazzy-rplidar-ros` 2.1.0 and an RPLIDAR on `/dev/ttyUSB0`:

```
[rplidar_composition-21] [INFO] [rplidar_ros.rplidar_node]: RPLIDAR running on ROS 2 package rplidar_ros. SDK Version: '1.12.0'
[rplidar_composition-21] [INFO] [rplidar_ros.rplidar_node]: RPLidar health status : '0'
[rplidar_composition-21] [INFO] [rplidar_ros.rplidar_node]: current scan mode: Express, max_distance: 12.0 m, Point number: 4.0K
```

`/rplidar_ros/scan` publishes at ~7.1 Hz across a full 360° with valid ranges, the console reports `Lidar status: connected`, and `deepracer-core` stays up with `NRestarts=0`.

I don't have a Foxy car to test the other branch on, so that path is unchanged-by-inspection rather than verified — worth a second opinion if anyone still runs 20.04.