### PR TITLE
Use legacy camera mode on x86_64 so stereo works on 24.04

### DIFF
--- a/build_scripts/files/common/start_ros.sh
+++ b/build_scripts/files/common/start_ros.sh
@@ -47,8 +47,12 @@ else
 fi
 
 # Determine camera mode
+# The original DeepRacer uses USB cameras, and only the legacy node detects a
+# stereo pair; the Raspberry Pi needs the libcamera-based modern node.
 if [ "$ROS_DISTRO" == "foxy" ]; then
     CAMERA_MODE=''
+elif [ "$(uname -m)" == "x86_64" ]; then
+    CAMERA_MODE='camera_mode:=legacy'
 else
     CAMERA_MODE='camera_mode:=modern'
 fi


### PR DESCRIPTION
Fixes #77

## Problem

`start_ros.sh` picked the camera mode by ROS distro, so every non-Foxy build got `modern`. That mode launches the single-camera `camera_ros` node, which has no stereo concept at all — only the legacy `camera_pkg` node probes for a pair:

```
[Camera Package] Single Camera Detected at index:  %d
[Camera Package] Stereo Cameras Detected at indexes:  %d, %d
```

So an original DeepRacer with a stereo pair reports `Stereo status: not_connected` on Ubuntu 24.04 no matter what hardware is attached. This also contradicts the README, which documents `camera_mode` as defaulting to `legacy` and lists "Original USB (incl. Stereo)" as supported for *Original (Ubuntu 24.04, ROS2 Jazzy)*.

## Change

The distro check was really standing in for hardware, so this selects on `uname -m` instead — matching how `INFERENCE_ENGINE` is already chosen a few lines above:

- **x86_64** (original car, USB cameras) → `legacy`
- **everything else** (RPi, libcamera) → `modern`
- **Foxy** → unchanged

## Verification

On Ubuntu 24.04 / Jazzy with two `29fe:4d53` USB cameras:

```
[camera_node-1] [INFO] [camera_pkg.camera_node]: [Camera Package] Stereo Cameras Detected at indexes:  4, 0
[webserver_publisher_node-18] [INFO] ...: Camera status: not_connected, Stereo status: connected, Lidar status: connected
```

`/camera_pkg/video_mjpeg` carries two JPEG images per message at ~27 Hz (both starting `255 216 255 224`, i.e. valid JPEG SOI/JFIF).

## Trade-off worth a maintainer's call

Legacy mode drives both cameras, so `/camera_pkg/display_mjpeg` drops from ~32 Hz to ~18–24 Hz. Users running only single-camera models may prefer `modern` and its higher frame rate.

If that makes this the wrong default, the alternative is to read the mode from a config file the way `logging_mode` already reads `/opt/aws/deepracer/logging.conf`, making it user-selectable rather than inferred. Happy to rework it that way — this version is the minimal fix that makes the documented behaviour true.

I only have original x86_64 hardware, so the RPi branch is unchanged but untested by me.